### PR TITLE
Adds dotenv-webpack plugin to support a .env file

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,1 @@
+IOBIO_URL=http://gru_backend

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ QuattrocentoSans-Italic.911cd9cc3f16643b8e2367faffd52d90.ttf
 deploy
 build.js.map
 exhibit-pattern.20b9de6cf0b5bc0e3cb4175cdc9959ee.png
+.env

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+## Create .env file
+
+```bash
+# replace iobio-url with the url of the gru backend service.
+
+echo "IOBIO_URL=iobio-url" > .env
+```
+
+[Sample env file](./.env.template)
+
 ## Starting App
 
 Using node version 8.5.x

--- a/client/app/App.vue
+++ b/client/app/App.vue
@@ -127,8 +127,10 @@ export default {
   data() {
     return {
     }
+  },
+  // remove this example!
+  mounted() {
+    console.log(process.env.IOBIO_URL);
   }
 }
 </script>
-
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -2316,6 +2316,30 @@
         "is-obj": "^1.0.0"
       }
     },
+    "dotenv": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
+      "dev": true
+    },
+    "dotenv-defaults": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-1.1.1.tgz",
+      "integrity": "sha512-6fPRo9o/3MxKvmRZBD3oNFdxODdhJtIy1zcJeUSCs6HCy4tarUpd+G67UTU9tF6OWXeSPqsm4fPAB+2eY9Rt9Q==",
+      "dev": true,
+      "requires": {
+        "dotenv": "^6.2.0"
+      }
+    },
+    "dotenv-webpack": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-1.7.0.tgz",
+      "integrity": "sha512-wwNtOBW/6gLQSkb8p43y0Wts970A3xtNiG/mpwj9MLUhtPCQG6i+/DSXXoNN7fbPCU/vQ7JjwGmgOeGZSSZnsw==",
+      "dev": true,
+      "requires": {
+        "dotenv-defaults": "^1.0.2"
+      }
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "clean-webpack-plugin": "^0.1.16",
     "cross-env": "^5.0.1",
     "css-loader": "^1.0.1",
+    "dotenv-webpack": "^1.7.0",
     "extract-text-webpack-plugin": "^2.1.2",
     "file-loader": "^0.11.2",
     "flush-promises": "^1.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
-var path = require('path')
 var webpack = require('webpack')
+const Dotenv = require('dotenv-webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var CleanWebpackPlugin = require('clean-webpack-plugin');
 var inProduction = process.env.NODE_ENV === 'production';
@@ -58,7 +58,8 @@ module.exports = {
     ]
   },
   plugins: [
-    new CleanWebpackPlugin(['client/dist'], {})
+    new CleanWebpackPlugin(['client/dist'], {}),
+    new Dotenv(),
   ],
   // resolve: {
   //   alias: {


### PR DESCRIPTION
## Changelog

- [x] Adds `dotenv-webpack` npm package to support a .env file.  Updates webpack config to use plugin.
- [x] Updates `README.md` with .env instructions

## Notes

- The webpack test config may need to be updated as well to prevent errors.
- I've added an example in `App.vue`.  Make sure to delete this.
