### PR TITLE
Add quarantest

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+rm -rf deploy
+mkdir deploy
+mkdir deploy/js
+mkdir deploy/app
+mkdir deploy/dist
+
+# build vue app
+if [[ $1 == "prod" ]]; then
+  echo "** Building prod **"
+  NODE_ENV=production npm run build
+  #npm run build
+elif [[ $1 == "stage" ]]; then
+  echo "** Building stage **"
+  NODE_ENV=production npm run build
+  #npm run build
+else
+  echo "** Building dev **"
+  npm run build
+fi
+
+working_dir=$PWD
+
+# link to files needed for static page
+ln -s $working_dir/server/views/index.html $working_dir/deploy/index.html
+ln -s $working_dir/client/data $working_dir/deploy/data
+ln -s $working_dir/client/assets $working_dir/deploy/assets
+ln -s $working_dir/client/js/thirdparty $working_dir/deploy/js/thirdparty
+ln -s $working_dir/client/app/third-party $working_dir/deploy/app/third-party
+ln -s $working_dir/client/dist/build.js $working_dir/deploy/dist/build.js
+if [[ $1 == "prod" ]]; then
+  ln -s $working_dir/client/dist/build.js.map $working_dir/deploy/dist/build.js.map
+fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,37 +1,6 @@
 #!/bin/bash
 
-rm -rf deploy
-mkdir deploy
-mkdir deploy/js
-mkdir deploy/app
-mkdir deploy/dist
-
-# build vue app
-if [[ $1 == "prod" ]]; then
-  echo "** Building prod **"
-  NODE_ENV=production npm run build
-  #npm run build
-elif [[ $1 == "stage" ]]; then
-  echo "** Building stage **"
-  NODE_ENV=production npm run build
-  #npm run build
-else
-  echo "** Building dev **"
-  npm run build
-fi
-
-working_dir=$PWD
-
-# link to files needed for static page
-ln -s $working_dir/server/views/index.html $working_dir/deploy/index.html
-ln -s $working_dir/client/data $working_dir/deploy/data
-ln -s $working_dir/client/assets $working_dir/deploy/assets
-ln -s $working_dir/client/js/thirdparty $working_dir/deploy/js/thirdparty
-ln -s $working_dir/client/app/third-party $working_dir/deploy/app/third-party
-ln -s $working_dir/client/dist/build.js $working_dir/deploy/dist/build.js
-if [[ $1 == "prod" ]]; then
-  ln -s $working_dir/client/dist/build.js.map $working_dir/deploy/dist/build.js.map
-fi
+./build.sh
 
 # upload to cloudfront
 if [[ $1 == "prod" ]]; then

--- a/quarantest.json
+++ b/quarantest.json
@@ -1,0 +1,4 @@
+{
+  "build_script": "build.sh",
+  "docker_image": "anderspitman/iobio-nodejs-12"
+}

--- a/quarantest.json
+++ b/quarantest.json
@@ -1,4 +1,4 @@
 {
-  "build_script": "build.sh",
+  "build_script": "quarantest_build.sh",
   "docker_image": "anderspitman/iobio-nodejs-12"
 }

--- a/quarantest_build.sh
+++ b/quarantest_build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd /src
+# TODO: figure out how to get rid of unsafe-perm
+npm install --unsafe-perm
+./build.sh prod
+# Need to use -L to follow symlinks otherwise they'll point to the wrong place
+# in the host environment
+cp -aL deploy/* /build/


### PR DESCRIPTION
@tonydisera I'm done with the MVP for my service for automatically creating demo versions of our apps for each pull requests (and actually each push). The service is called quarantest. This PR adds the necessary plumbing for gene to interact with the service. The biggest change is factoring out some of the deploy script into a separate build.sh script, which can be re-used by quarantest.

I've already added the necessary webhook. Once this is merged, the quarantest bot will automatically create links like this for each push, and post them on the appropriate PRs:

[http://9c821f4cbe9316133983b43c4918441b5da8a226.quarantest.iobio.io/](http://9c821f4cbe9316133983b43c4918441b5da8a226.quarantest.iobio.io/)