### PR TITLE
showing mother and father when launched from WES, this showed a relat…

### DIFF
--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -257,6 +257,7 @@ main.content.clin, main.v-content.clin
       @analyze-all="onAnalyzeAll"
       @call-variants="callVariants"
       @filter-settings-applied="onFilterSettingsApplied"
+      @isDemo="onIsDemo"
     >
     </navigation>
 
@@ -359,11 +360,14 @@ main.content.clin, main.v-content.clin
         </gene-variants-card>
 
               <div
-                      v-if="geneModel && (!launchedFromDemo && !launchedFromHub)"
+                      v-if="geneModel && (!launchedFromDemo && !launchedFromHub) && !launchedFromFiles && !launchedFromClin"
+                      v-show="geneModel && (!launchedFromDemo && !launchedFromHub) && !launchedFromFiles && !launchedFromClin"
+
                       style="height: 15px"></div>
 
           <gene-viz class="gene-viz-zoom"
-                    v-if="geneModel && (!launchedFromDemo && !launchedFromHub)"
+                    v-if="geneModel && (!launchedFromDemo && !launchedFromHub && !launchedFromFiles && !launchedFromClin)"
+                    v-show="geneModel && (!launchedFromDemo && !launchedFromHub && !launchedFromFiles && !launchedFromClin)"
                     :data="[selectedTranscript]"
                     :margin="geneVizMargin"
                     :height="40"
@@ -822,6 +826,7 @@ export default {
 
       launchedFromHub: false,
       launchedFromSFARI: false,
+      launchedFromFiles: false,
       isHubDeprecated: false,
       sampleId: null,
       projectId: null,
@@ -1663,6 +1668,8 @@ export default {
 
     onFilesLoaded: function(analyzeAll, callback) {
       let self = this;
+
+      this.launchedFromFiles = true;
 
       self.showWelcome = false;
       self.setUrlParameters();
@@ -2574,7 +2581,7 @@ export default {
       }
 
       self.globalApp.initServices(self.launchedFromHub);
-      self.phenotypeLookupUrl = self.globalApp.hpoLookupUrl;        
+      self.phenotypeLookupUrl = self.globalApp.hpoLookupUrl;
     },
     promiseInitFromUrl: function() {
       let self = this;
@@ -3112,6 +3119,11 @@ export default {
       this.cohortModel.stopAnalysis();
       this.cacheHelper.stopAnalysis();
     },
+    onIsDemo: function(bool){
+      this.isMother = bool;
+      this.isFather = bool;
+      this.launchedFromDemo = bool;
+    },
     onShowSnackbar: function(snackbar) {
       if (snackbar && snackbar.message) {
         this.showSnackbar = true;
@@ -3307,7 +3319,7 @@ export default {
 
             if (self.geneModel) {
               self.geneModel.setRankedGenes({'gtr': clinObject.gtrFullList, 'phenolyzer': clinObject.phenolyzerFullList })
-              self.geneModel.setGenePhenotypeHitsFromClin(clinObject.genesReport);              
+              self.geneModel.setGenePhenotypeHitsFromClin(clinObject.genesReport);
             }
 
             console.log("gene.iobio set-data promiseInitClin")

--- a/client/app/components/partials/FilesDialog.vue
+++ b/client/app/components/partials/FilesDialog.vue
@@ -355,6 +355,7 @@ export default {
     },
     onLoadDemoData: function() {
       let self = this;
+      this.$emit('isDemo', true);
 
       if (self.mode == 'single') {
         self.mode = 'trio';

--- a/client/app/components/viz/Navigation.vue
+++ b/client/app/components/viz/Navigation.vue
@@ -750,6 +750,7 @@ nav.toolbar, nav.v-toolbar
      @on-files-loaded="onFilesLoaded"
      @load-demo-data="onLoadDemoData"
      @on-cancel="showFiles = false"
+     @isDemo="onIsDemo"
     >
     </files-dialog>
 
@@ -1116,6 +1117,9 @@ export default {
     onApplyVariantInterpretation: function(variant) {
       this.$emit("apply-variant-interpretation", variant);
     },
+    onIsDemo: function(bool){
+      this.$emit("isDemo", bool);
+    },
     onSearchPhenolyzerGenes: function(searchTerm) {
       let self = this;
       let genesToApply = null;
@@ -1198,6 +1202,7 @@ export default {
     onShowCoverageThreshold: function() {
       this.$emit('show-coverage-threshold', true)
     },
+
     onShowOptions: function() {
       this.showOptions = true;
     },


### PR DESCRIPTION
This pull request includes fixes to two issues that are related to each other.  The gene-viz was showing both when launched from clin, and when launched from WES demo file upload do to unhandled cases.  The WES demo data other tracks weren't being shown, as it was being treated as launched from file upload, rather than from demo data.  This PR addresses the displaying of Mother and Father other tracks when launched from WES demo file upload, and the unintentional rendering of gene-viz when launched from File Upload or when launched from Clin.  I will only address one issue per pull request in future PR submissions.  Sorry if this PR is unclear or confusing, feel free to ask me any questions