### PR TITLE
fix-associated genes not showing in clin.iobio

### DIFF
--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -3715,10 +3715,6 @@ export default {
     applyGenesClin: function(clinObject) {
       let self = this;
 
-      if (self.clinSetData == null || !self.clinSetData.isImported || !self.clinSetData.isCacheSet) {
-        return;
-      }
-
       /*
       let genesToProcess = [];
       let candidateGenesOld = $.extend({}, self.geneModel.candidateGenes);


### PR DESCRIPTION
This Pull request should fix the following issue in clin.iobio repo: https://github.com/iobio/clin.iobio/issues/131

Testing steps: 
Use the branch fix-gene-association 

**Standalone mode**: 

1. Launch clin.iobio (localhost:4030) and load with demo data. 
2. Go to step 2 (select phenotypes) and submit the example note.
3. Select the condition (ex. Dejerine sotas disease) and phenotypes (ex. charcot marie tooth disease and dejerine sotas disease) and generate the gene list 
4. Go to step 3 (Review variants). Variant PRX should show Gene Associations (See screenshot). The current version of clin.iobio is not showing any gene associations.  
5. Mark the variant as significant
6. Go to step 4 (Report findings). Gene association should be shown for gene PRX. 

 
<img width="1680" alt="Screen Shot 2020-04-02 at 2 51 57 PM" src="https://user-images.githubusercontent.com/16284713/78303527-a9a00b80-74f1-11ea-8345-ff801e0ae900.png">



**Launch from Mosiac** 
Select MPPH case and launch clin.iobio 
Go to step 2 (select phenotypes) and enter the condition (ex. **hydrocephalus**) as input 
Select the condition (ex. hydrocephalus) and phenotypes (ex. hydrocephalus) and generate the gene list
Go to step 3 (Review variants). Variant CCND2 should show Gene Associations 
Save the analysis 
Go to the Analysis tab in Utah Mosaic 
Select the saved analysis and launch Mosaic 
Go to step 3 and verify that Gene association is shown for the variant CCND2. 
