### PR TITLE
Set stage auto deployment

### DIFF
--- a/.github/workflows/deployStage.yml
+++ b/.github/workflows/deployStage.yml
@@ -1,0 +1,101 @@
+name: Staging Build
+
+on:
+  push:
+    branches:
+    - dev
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        node-version: [12.x]
+        
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: NPM Install
+      run: |
+        npm install
+    - name: Dev Build
+      run: |
+        NODE_ENV=production npm run build
+    - name: Deploy to S3 dev bucket - index.html
+      uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read --delete
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-east-1'
+        SOURCE_DIR: "server/views"
+        DEST_DIR: "stage/gene.iobio.io"
+    - name: Deploy to S3 dev bucket - data
+      uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read --delete
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-east-1'
+        SOURCE_DIR: "client/data"
+        DEST_DIR: "stage/gene.iobio.io/data"
+    - name: Deploy to S3 dev bucket - assets
+      uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read --delete
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-east-1'
+        SOURCE_DIR: "client/assets"
+        DEST_DIR: "stage/gene.iobio.io/assets"
+    - name: Deploy to S3 dev bucket -app 
+      uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read --delete
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-east-1'
+        SOURCE_DIR: "client/app/third-party"
+        DEST_DIR: "stage/gene.iobio.io/app/third-party"
+    - name: Deploy to S3 dev bucket -js/thirdparty 
+      uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read --delete
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-east-1'
+        SOURCE_DIR: "client/js/thirdparty"
+        DEST_DIR: "stage/gene.iobio.io/js/thirdparty"    
+    - name: Deploy to S3 dev bucket - build.js
+      uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read --delete
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-east-1'
+        SOURCE_DIR: "client/dist"
+        DEST_DIR: "stage/gene.iobio.io/dist"            
+    - name: Invalidate CloudFront
+      uses: chetan/invalidate-cloudfront-action@master
+      env:
+        DISTRIBUTION: ${{ secrets.DISTRIBUTION_STAGE_ID }}
+        PATHS: '/*'
+        AWS_REGION: 'us-east-1'
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deployStage.yml
+++ b/.github/workflows/deployStage.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Dev Build
       run: |
         NODE_ENV=production npm run build
-    - name: Deploy to S3 dev bucket - index.html
+    - name: Deploy to S3 stage bucket - index.html
       uses: jakejarvis/s3-sync-action@master
       with:
         args: --acl public-read --delete
@@ -36,7 +36,7 @@ jobs:
         AWS_REGION: 'us-east-1'
         SOURCE_DIR: "server/views"
         DEST_DIR: "stage/gene.iobio.io"
-    - name: Deploy to S3 dev bucket - data
+    - name: Deploy to S3 stage bucket - data
       uses: jakejarvis/s3-sync-action@master
       with:
         args: --acl public-read --delete
@@ -47,7 +47,7 @@ jobs:
         AWS_REGION: 'us-east-1'
         SOURCE_DIR: "client/data"
         DEST_DIR: "stage/gene.iobio.io/data"
-    - name: Deploy to S3 dev bucket - assets
+    - name: Deploy to S3 stage bucket - assets
       uses: jakejarvis/s3-sync-action@master
       with:
         args: --acl public-read --delete
@@ -58,7 +58,7 @@ jobs:
         AWS_REGION: 'us-east-1'
         SOURCE_DIR: "client/assets"
         DEST_DIR: "stage/gene.iobio.io/assets"
-    - name: Deploy to S3 dev bucket -app 
+    - name: Deploy to S3 stage bucket -app 
       uses: jakejarvis/s3-sync-action@master
       with:
         args: --acl public-read --delete
@@ -69,7 +69,7 @@ jobs:
         AWS_REGION: 'us-east-1'
         SOURCE_DIR: "client/app/third-party"
         DEST_DIR: "stage/gene.iobio.io/app/third-party"
-    - name: Deploy to S3 dev bucket -js/thirdparty 
+    - name: Deploy to S3 stage bucket -js/thirdparty 
       uses: jakejarvis/s3-sync-action@master
       with:
         args: --acl public-read --delete
@@ -80,7 +80,7 @@ jobs:
         AWS_REGION: 'us-east-1'
         SOURCE_DIR: "client/js/thirdparty"
         DEST_DIR: "stage/gene.iobio.io/js/thirdparty"    
-    - name: Deploy to S3 dev bucket - build.js
+    - name: Deploy to S3 stage bucket - build.js
       uses: jakejarvis/s3-sync-action@master
       with:
         args: --acl public-read --delete


### PR DESCRIPTION
This pull request will set up auto-deployment on `dev` branch. 
Successful merge or push to `dev` will deploy it automatically to https://stage.clin.iobio.io/

Workflow: 

- Install dependencies 
- Build project 
- Upload content to S3 bucket (stage/gene.iobio.ioo)
- Invalidate CloudFront distribution 

Any point of failure in the above workflow will fail the process and stop the deployment to stage.gene.iobio.io

This script has been tested on dev.gene and the current version (2018-11-06 18:57 PT) of http://dev.gene.iobio.io/ was deployed with it 

@tonydisera @mvelinder 