### PR TITLE
proper checking if transcript is null, emit snackbar error message an…

### DIFF
--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -853,7 +853,7 @@ export default {
         // backward compatible with old clin.iobio
         "mosaic.chpc.utah.edu":                  {iobio: "mosaic.chpc.utah.edu/gru/api/v1", batchSize: 10},
         "nv-prod.iobio.io":                      {iobio: "mosaic.chpc.utah.edu/gru/api/v1", batchSize: 10},
-        
+
         "https://staging.frameshift.io":         {iobio: "backend.iobio.io",     batchSize: 10},
         "https://mosaic.frameshift.io":          {iobio: "backend.iobio.io",     batchSize: 10}
       },
@@ -1654,6 +1654,11 @@ export default {
                     self.cohortModel.promiseMarkCodingRegions(self.selectedGene, self.selectedTranscript)
                         .then(function(data) {
                             self.analyzedTranscript = data.transcript;
+
+                            if(self.analyzedTranscript.gene_name !== self.selectedGene.gene_name){
+                              self.geneModel.removeGene(self.selectedGene.gene_name);
+                              self.onShowSnackbar({message: 'Bypassing ' + self.selectedGene.gene_name + '. Unable to find transcripts.', timeout: 5000})
+                            }
                             resolve();
                         })
 
@@ -1997,7 +2002,7 @@ export default {
         .catch(function(error) {
           console.log(error);
           self.geneModel.removeGene(geneName);
-          self.onShowSnackbar({message: 'Bypassing ' + geneName + '. Unable to find transcripts.', timeout: 60000})
+          self.onShowSnackbar({message: 'Bypassing ' + geneName + '. Unable to find transcripts.', timeout: 5000})
         })
       })
     },


### PR DESCRIPTION
Fixed bug where null transcript wasn't triggering the bypassing gene snackbar and gene removal.  Now a gene with an unknown transcript will trigger this popover, and the snackbar will only stay for 5 seconds, instead of 60