### PR TITLE
removing SFARI from optional tracks 

### DIFF
--- a/client/app/components/partials/OptionalTracksMenu.vue
+++ b/client/app/components/partials/OptionalTracksMenu.vue
@@ -80,19 +80,6 @@
           >
           </known-variants-toolbar>
         </div>
-
-        <div style="display:flex;flex-flow:column">
-          <v-checkbox label="SFARI"   v-model="showSfariVariantsCard"></v-checkbox>
-          <sfari-variants-toolbar
-            v-if="showSfariVariantsCard"
-            @sfariVariantsVizChange="onSfariVariantsVizChange"
-            @sfariVariantsFilterChange="onSfariVariantsFilterChange">
-          </sfari-variants-toolbar>
-      </div>
-
-
-
-
       </div>
 
     </v-menu>


### PR DESCRIPTION
removing sfari from optional tracks as the SFARI data is not available to the public.  We will likely need a way to figure out how to display this track only to authorized users in the future.  This PR is associated with issue 155 in the Clin board.