### PR TITLE
Notes no sig

### DIFF
--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -2362,8 +2362,8 @@ export default {
 
     isNewAnalysis: function() {
       return ( (this.analysis && !this.analysis.hasOwnProperty("id"))
-              || !this.analysis.id
-              || this.analysis.id == "");
+              ||  (this.analysis && !this.analysis.id)
+              || (this.analysis && this.analysis.id == ""));
     },
 
     removeGeneImpl: function(geneName) {

--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -2823,7 +2823,6 @@ export default {
     },
     onApplyVariantNotes: function(variant) {
       let self = this;
-
       // If the variant isn't in the filtered variants list,
       // mark it as 'user flagged'
       if (self.cohortModel.getFlaggedVariant(variant) == null) {
@@ -2847,6 +2846,11 @@ export default {
 
       if (self.$refs.navRef && self.$refs.navRef.$refs.flaggedVariantsRef) {
         self.$refs.navRef.$refs.flaggedVariantsRef.populateGeneLists()
+      }
+
+      if(typeof variant.interpretation === 'undefined' || (variant.interpretation === "not-reviewed")){
+        variant.interpretation = 'unknown-sig';
+        self.onApplyVariantInterpretation(variant);
       }
 
     },


### PR DESCRIPTION
Issue #374: In clin.iobio, reviewed variants left pannel is auto refreshed to display significance when variant significance is selected.

Issue #376: When a note is added to a variant, and no significance is selected, significance defaults to unknown-significance (Depends on fix for #374 to work properly with left panel refreshing to show updated significance)