### PR TITLE
#449 Fix null ref when moving immediately to 'Review variants'  from …

### DIFF
--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -3797,7 +3797,9 @@ export default {
 
       self.selectedGene = null;
       self.selectedTranscript = null;
-      self.onFlaggedVariantSelected(self.selectedVariant, {force: true})
+      if (self.selectedVariant && self.selectedVariant.hasOwnProperty('gene')) {
+        self.onFlaggedVariantSelected(self.selectedVariant, {force: true})
+      }
 
       /*
       if (clinObject.genes && Array.isArray(clinObject.genes)) {


### PR DESCRIPTION
…'Enter phenotypes'.

Adit, this fixes the null ref, but we still have a problem when moving immediately to 'Review variants'.  I'll submit a new issue to show the problem.