### PR TITLE
Clin var freq

### DIFF
--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -3092,18 +3092,14 @@ export default {
     },
     onCoverageThresholdApplied: function() {
       let self = this;
-      self.cohortModel.cacheHelper.refreshGeneBadges(function() {
-        self.showLeftPanelForGenes();
 
         self.refreshCoverageCounts();
         if (self.selectedGene && self.selectedGene.gene_name) {
           self.onGeneSelected(self.selectedGene.gene_name);
         }
-
         if (self.launchedFromClin) {
           self.onSendFiltersToClin();
         }
-      })
     },
     onLeftDrawer: function(isOpen) {
       if (!this.isEduMode) {

--- a/client/app/components/viz/VariantInspectCard.vue
+++ b/client/app/components/viz/VariantInspectCard.vue
@@ -367,7 +367,7 @@
 
       <v-spacer></v-spacer>
 
-      <div v-if="!isSimpleMode && selectedVariant && !showAssessment && selectedVariantInterpretation != 'known-variantsss'" style="margin-left:20px;margin-right:0px">
+      <div v-if="!isSimpleMode && selectedVariant && !showAssessment" style="margin-left:20px;margin-right:0px">
         <v-btn raised id="show-assessment-button" @click="onEnterComments">
           <v-icon>gavel</v-icon>
           Review
@@ -515,7 +515,7 @@
           </div>
       </div>
 
-      <div class="variant-inspect-column" style="min-width:90px" v-if="!isSimpleMode && selectedVariant && selectedVariantRelationship != 'known-variantsss' && selectedVariant.inheritance.length > 0">
+      <div class="variant-inspect-column" style="min-width:90px" v-if="!isSimpleMode && selectedVariant && selectedVariant.inheritance.length > 0">
           <div class="variant-column-header">
             Inheritance
             <v-divider></v-divider>

--- a/client/app/components/viz/VariantInspectCard.vue
+++ b/client/app/components/viz/VariantInspectCard.vue
@@ -307,7 +307,7 @@
 
       </div>
 
-        
+
       <variant-links-menu
       v-if="selectedVariant && info"
       :selectedGene="selectedGene"
@@ -367,7 +367,7 @@
 
       <v-spacer></v-spacer>
 
-      <div v-if="!isSimpleMode && selectedVariant && !showAssessment && selectedVariantInterpretation != 'known-variants'" style="margin-left:20px;margin-right:0px">
+      <div v-if="!isSimpleMode && selectedVariant && !showAssessment && selectedVariantInterpretation != 'known-variantsss'" style="margin-left:20px;margin-right:0px">
         <v-btn raised id="show-assessment-button" @click="onEnterComments">
           <v-icon>gavel</v-icon>
           Review
@@ -497,7 +497,7 @@
       </div>
 
 
-      <div class="variant-inspect-column" v-if="selectedVariant && selectedVariantRelationship != 'known-variants'">
+      <div class="variant-inspect-column" v-if="selectedVariant">
           <div class="variant-column-header">
               {{ isSimpleMode ? 'Population Frequency' : 'Pop Freq in gnomAD' }}
             <info-popup v-if="!isSimpleMode" name="gnomAD"></info-popup>
@@ -515,7 +515,7 @@
           </div>
       </div>
 
-      <div class="variant-inspect-column" style="min-width:90px" v-if="!isSimpleMode && selectedVariant && selectedVariantRelationship != 'known-variants' && selectedVariant.inheritance.length > 0">
+      <div class="variant-inspect-column" style="min-width:90px" v-if="!isSimpleMode && selectedVariant && selectedVariantRelationship != 'known-variantsss' && selectedVariant.inheritance.length > 0">
           <div class="variant-column-header">
             Inheritance
             <v-divider></v-divider>
@@ -742,9 +742,23 @@ export default {
 
     },
 
+    annotateClinVarVariant(){
+      console.log("annotating clin var variant...");
+      this.refreshSelectedVariantInfo();
+      console.log('this.selectedVariantInfo', this.selectedVariantInfo);
+    },
 
 
-    formatPopAF: function(afObject) {
+
+      refreshSelectedVariantInfo: function() {
+          if (this.selectedVariant) {
+              this.selectedVariantInfo =  this.globalApp.utility.formatDisplay(this.selectedVariant, this.cohortModel.translator, this.isEduMode)
+          } else {
+              this.selectedVariantInfo = null;
+          }
+      },
+
+      formatPopAF: function(afObject) {
       let self = this;
       var popAF = "";
       if (afObject['AF'] != ".") {
@@ -1385,7 +1399,8 @@ export default {
     },
 
 
-    coord: function() {
+
+      coord: function() {
       let self = this;
       if (self.selectedVariant) {
         return self.selectedVariant.chrom + ":" + self.selectedVariant.start;
@@ -1493,8 +1508,17 @@ export default {
   watch: {
 
     selectedVariant: function() {
+
+        let self = this;
+        console.log("selected Variant in watcher", this.selectedVariant);
+        console.log("this.selectedVariantRelationship", this.selectedVariantRelationship);
+
       this.$nextTick(function() {
-        this.loadData();
+          this.loadData();
+
+          if (self.selectedVariantRelationship === "known-variants") {
+              self.annotateClinVarVariant(self.selectedVariant);
+          }
       })
     },
   },
@@ -1521,6 +1545,7 @@ export default {
   },
 
   mounted: function() {
+
   },
 
   created: function() {

--- a/client/app/components/viz/VariantInspectCard.vue
+++ b/client/app/components/viz/VariantInspectCard.vue
@@ -1509,10 +1509,7 @@ export default {
 
     selectedVariant: function() {
 
-        let self = this;
-        console.log("selected Variant in watcher", this.selectedVariant);
-        console.log("this.selectedVariantRelationship", this.selectedVariantRelationship);
-
+      let self = this;
       this.$nextTick(function() {
           this.loadData();
 

--- a/client/app/components/viz/VariantInspectCard.vue
+++ b/client/app/components/viz/VariantInspectCard.vue
@@ -749,10 +749,9 @@ export default {
     },
 
     annotateClinVarVariant(){
-      console.log("annotating clin var variant...");
       this.refreshSelectedVariantInfo();
-      console.log('this.selectedVariantInfo', this.selectedVariantInfo);
     },
+
 
 
 

--- a/client/app/models/SampleModel.js
+++ b/client/app/models/SampleModel.js
@@ -1377,8 +1377,8 @@ class SampleModel {
                me.globalApp.vepAF, // vepAF
                me.globalApp.useServerCache, // serverside cache
                false, // sfari mode
-               me.globalApp.gnomADExtra && me.relationship != 'known-variantsss', // get extra gnomad,
-               me.relationship != 'known-variantsss' // decompose
+               me.globalApp.gnomADExtra, // get extra gnomad,
+               true // decompose
             ).then( function(data) {
 
               var rawVcfRecords = data[0];
@@ -1818,7 +1818,7 @@ class SampleModel {
                regions,   // regions
                isMultiSample, // is multi-sample
                me._getSamplesToRetrieve(),
-               me.getRelationship() === 'known-variantsss' ? 'none' : me.getAnnotationScheme().toLowerCase(),
+               'none',
                me.getTranslator().clinvarMap,
                me.getGeneModel().geneSource === 'refseq' ? true : false,
                me.isBasicMode || me.globalApp.getVariantIdsForGene,  // hgvs notation
@@ -1826,8 +1826,8 @@ class SampleModel {
                me.globalApp.vepAF,    // vep af
                false, // serverside cache
                false, // sfari mode
-               me.globalApp.gnomADExtraAll && me.relationship != 'known-variantsss', // get extra gnomad,
-               !me.isEduMode && me.getRelationship() != 'known-variantsss' // decompose
+               me.globalApp.gnomADExtraAll, // get extra gnomad,
+               !me.isEduMode// decompose
               );
           })
           .then( function(data) {
@@ -1888,7 +1888,6 @@ class SampleModel {
                   // Set the highest allele freq for all variants
                   for (var key in resultMap) {
                     var theVcfData = resultMap[key];
-                    console.log("key, vcfData", key, theVcfData)
                     if (theVcfData && theVcfData.features) {
                       theVcfData.features.forEach(function(variant) {
                         me._determineHighestAf(variant);
@@ -2073,9 +2072,6 @@ class SampleModel {
     // Find the highest value (the least rare AF) betweem exac and 1000g to evaluate
     // as 'lowest' af for all variants in gene
     var afHighest = null;
-
-    console.log("variant in sampleModel", variant);
-    console.log("me.relationship", me.relationship);
 
     if ($.isNumeric(variant.afExAC) && $.isNumeric(variant.af1000G)) {
       // Ignore exac n/a.  If exac is higher than 1000g, evaluate exac

--- a/client/app/models/SampleModel.js
+++ b/client/app/models/SampleModel.js
@@ -1377,8 +1377,8 @@ class SampleModel {
                me.globalApp.vepAF, // vepAF
                me.globalApp.useServerCache, // serverside cache
                false, // sfari mode
-               me.globalApp.gnomADExtra && me.relationship != 'known-variants', // get extra gnomad,
-               me.relationship != 'known-variants' // decompose
+               me.globalApp.gnomADExtra && me.relationship != 'known-variantsss', // get extra gnomad,
+               me.relationship != 'known-variantsss' // decompose
             ).then( function(data) {
 
               var rawVcfRecords = data[0];
@@ -1818,7 +1818,7 @@ class SampleModel {
                regions,   // regions
                isMultiSample, // is multi-sample
                me._getSamplesToRetrieve(),
-               me.getRelationship() === 'known-variants' ? 'none' : me.getAnnotationScheme().toLowerCase(),
+               me.getRelationship() === 'known-variantsss' ? 'none' : me.getAnnotationScheme().toLowerCase(),
                me.getTranslator().clinvarMap,
                me.getGeneModel().geneSource === 'refseq' ? true : false,
                me.isBasicMode || me.globalApp.getVariantIdsForGene,  // hgvs notation
@@ -1826,8 +1826,8 @@ class SampleModel {
                me.globalApp.vepAF,    // vep af
                false, // serverside cache
                false, // sfari mode
-               me.globalApp.gnomADExtraAll && me.relationship != 'known-variants', // get extra gnomad,
-               !me.isEduMode && me.getRelationship() != 'known-variants' // decompose
+               me.globalApp.gnomADExtraAll && me.relationship != 'known-variantsss', // get extra gnomad,
+               !me.isEduMode && me.getRelationship() != 'known-variantsss' // decompose
               );
           })
           .then( function(data) {
@@ -1888,6 +1888,7 @@ class SampleModel {
                   // Set the highest allele freq for all variants
                   for (var key in resultMap) {
                     var theVcfData = resultMap[key];
+                    console.log("key, vcfData", key, theVcfData)
                     if (theVcfData && theVcfData.features) {
                       theVcfData.features.forEach(function(variant) {
                         me._determineHighestAf(variant);
@@ -2072,6 +2073,10 @@ class SampleModel {
     // Find the highest value (the least rare AF) betweem exac and 1000g to evaluate
     // as 'lowest' af for all variants in gene
     var afHighest = null;
+
+    console.log("variant in sampleModel", variant);
+    console.log("me.relationship", me.relationship);
+
     if ($.isNumeric(variant.afExAC) && $.isNumeric(variant.af1000G)) {
       // Ignore exac n/a.  If exac is higher than 1000g, evaluate exac
       if (variant.afExAC > -100 && variant.afExAC >= variant.af1000G) {


### PR DESCRIPTION
Display genomAD pop frequencies for clinVar variants.  It seems like most clinVar variants have a gnomAd pop frequency of 0 or null, so you may have to check multiple genes before finding a clinVar variant with a gnomAd frequency above 0.  I have included screenshots of a couple of clinVar variants with non-null gnomAD frequencies for verification.  If it is unexpected that we would be seeing this many clinVar variants with null or 0 AF in gnomAD,  let me know and I can further investigate if this correctly displays gnomAD AF for all clinVar variants!
<img width="1032" alt="Screen Shot 2020-04-17 at 12 03 58 PM" src="https://user-images.githubusercontent.com/15776714/79602065-0fba9000-80a7-11ea-95b1-bbf4ffcb364a.png">
<img width="1349" alt="Screen Shot 2020-04-17 at 12 18 06 PM" src="https://user-images.githubusercontent.com/15776714/79602067-10532680-80a7-11ea-9230-070ed12a7f4c.png">

