### PR TITLE
Close review

### DIFF
--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -1273,12 +1273,10 @@ export default {
 
     },
 
-    hasVariantAssessmentCheck: function() {
-      let self = this;
-
-      if (self.selectedVariant) {
-        if ((self.selectedVariant.interpretation && self.selectedVariant.interpretation != 'not-reviewed')
-                || (self.selectedVariant.notes && self.selectedVariant.notes != null && self.selectedVariant.notes.length > 0)) {
+    hasVariantAssessmentCheck: function(selectedVariant) {
+      if (selectedVariant) {
+        if ((selectedVariant.interpretation && selectedVariant.interpretation != 'not-reviewed')
+                || (selectedVariant.notes && selectedVariant.notes != null && selectedVariant.notes.length > 0)) {
           return true;
         } else {
           return false;
@@ -2889,8 +2887,8 @@ export default {
     onFlaggedVariantSelected: function(flaggedVariant, options={}, callback) {
       let self = this;
 
-      this.hasVariantAssessment = this.hasVariantAssessmentCheck();
-
+      this.hasVariantAssessment = this.hasVariantAssessmentCheck(flaggedVariant);
+      this.showVariantAssessment = false;
 
       let canonicalTranscript = self.geneModel.getCanonicalTranscript(flaggedVariant.gene);
 

--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -535,7 +535,7 @@ main.content.clin, main.v-content.clin
             style="overflow-y:scroll;max-width:320px;margin-left:5px">
             <div class="variant-assessment-heading">
               Variant Review
-              <v-btn  id="variant-assessment-close-button" class="toolbar-button" flat @click="showVariantAssessment = false">
+              <v-btn  id="variant-assessment-close-button" class="toolbar-button" flat @click="showVariantAssessmentClose()">
                 <v-icon >close</v-icon>
               </v-btn>
             </div>
@@ -828,6 +828,7 @@ export default {
     let self = this;
     return {
 
+      hasVariantAssessment: false,
       geneVizMargin: {
         top: 0,
         right: self.isBasicMode || self.isEduMode ? 7 : 2,
@@ -1103,22 +1104,6 @@ export default {
         return null;
       }
     },
-    hasVariantAssessment: function() {
-      let self = this;
-      if (self.selectedVariant) {
-        if ((self.selectedVariant.interpretation && self.selectedVariant.interpretation != 'not-reviewed')
-            || (self.selectedVariant.notes && self.selectedVariant.notes != null && self.selectedVariant.notes.length > 0)) {
-          return true;
-        } else {
-          return false;
-        }
-      } else {
-        return false;
-      }
-
-    }
-
-
 
   },
 
@@ -1286,6 +1271,27 @@ export default {
 
       })
 
+    },
+
+    hasVariantAssessmentCheck: function() {
+      let self = this;
+
+      if (self.selectedVariant) {
+        if ((self.selectedVariant.interpretation && self.selectedVariant.interpretation != 'not-reviewed')
+                || (self.selectedVariant.notes && self.selectedVariant.notes != null && self.selectedVariant.notes.length > 0)) {
+          return true;
+        } else {
+          return false;
+        }
+      } else {
+        return false;
+      }
+
+    },
+
+    showVariantAssessmentClose(){
+      this.showVariantAssessment = false;
+      this.hasVariantAssessment = false;
     },
 
     onRegionZoom: function(regionStart, regionEnd) {
@@ -2882,6 +2888,8 @@ export default {
     },
     onFlaggedVariantSelected: function(flaggedVariant, options={}, callback) {
       let self = this;
+
+      this.hasVariantAssessment = this.hasVariantAssessmentCheck();
 
 
       let canonicalTranscript = self.geneModel.getCanonicalTranscript(flaggedVariant.gene);


### PR DESCRIPTION
**This issue was caused when a variant was assigned a significance, then deselected and reselected.  This PR fixes this issue, and allows for the proper opening, closing, and conditional rendering of the review variant panel.**

Bugs/undesirable behavior discovered but not introduced by this PR: 
1) When a variant selected in the left panel, and the transcript is changed, the variant needs to be reselected in the left panel for the Variant-All-Card to be rendered.

2) When a variant is selected,  and the transcript is changed, then the variant is deselected and reselected, the canonical transcript is gotten for the variant, and the change in the transcript was not saved.  This is inconsistent with the transcript behavior when a gene is selected, the transcript is changed, then the gene is deselected and reselected.

I will open issues for these discovered bugs and assign myself to them, but I just wanted to document that these issues were not introduced in this PR for bookkeeping.  **I can avoid putting discovered bugs in the PR comment if this is confusing and clutters the relevant information relating to the PR  in the future!**