### PR TITLE
update variant-detail-card on user entered phenotype

### DIFF
--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -2533,7 +2533,6 @@ export default {
 
         ).set('labels', {ok:'Replace gene list', cancel:'Combine genes with current list'});
 
-
       } else {
         doIt();
       }
@@ -2896,8 +2895,7 @@ export default {
     },
     onFlaggedVariantSelected: function(flaggedVariant, options={}, callback) {
       let self = this;
-
-
+      
       if(flaggedVariant === null){
         this.selectedVariant = null;
         return;

--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -507,7 +507,7 @@ main.content.clin, main.v-content.clin
         <div style="display:flex;align-items:stretch">
           <variant-inspect-card
           ref="variantInspectRef"
-          v-if="cohortModel && cohortModel.isLoaded && !isBasicMode && !isEduMode"
+          v-if="cohortModel && cohortModel.isLoaded && !isBasicMode && !isEduMode && selectedVariant"
           :isSimpleMode="isSimpleMode"
           :selectedGene="selectedGene"
           :selectedTranscript="analyzedTranscript"
@@ -1109,6 +1109,11 @@ export default {
   },
 
   watch: {
+
+    selectedVariant: function(){
+      console.log("selected variant in watcher", this.selectedVariant);
+    },
+
     isLeftDrawerOpen: function() {
       let self = this;
       setTimeout(function() {
@@ -2527,6 +2532,7 @@ export default {
 
         ).set('labels', {ok:'Replace gene list', cancel:'Combine genes with current list'});
 
+
       } else {
         doIt();
       }
@@ -2888,6 +2894,12 @@ export default {
     },
     onFlaggedVariantSelected: function(flaggedVariant, options={}, callback) {
       let self = this;
+
+
+      if(flaggedVariant === null){
+        this.selectedVariant = null;
+        return;
+      }
 
       this.hasVariantAssessment = this.hasVariantAssessmentCheck(flaggedVariant);
       this.showVariantAssessment = false;
@@ -3887,6 +3899,7 @@ export default {
 
             self.toClickVariant = firstFlaggedVariant;
             self.showLeftPanelWhenFlaggedVariants();
+            console.log("selecting first flagged variant");
             self.onFlaggedVariantSelected(firstFlaggedVariant, {}, function() {
               resolve()
             })

--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -1115,11 +1115,6 @@ export default {
   },
 
   watch: {
-
-    selectedVariant: function(){
-      console.log("selected variant in watcher", this.selectedVariant);
-    },
-
     isLeftDrawerOpen: function() {
       let self = this;
       setTimeout(function() {
@@ -3905,7 +3900,6 @@ export default {
 
             self.toClickVariant = firstFlaggedVariant;
             self.showLeftPanelWhenFlaggedVariants();
-            console.log("selecting first flagged variant");
             self.onFlaggedVariantSelected(firstFlaggedVariant, {}, function() {
               resolve()
             })

--- a/client/app/components/viz/Navigation.vue
+++ b/client/app/components/viz/Navigation.vue
@@ -1267,9 +1267,7 @@ export default {
     onFlaggedVariantCountChanged: function(count) {
       this.flaggedVariantCount = count;
       if(this.flaggedVariantCount === 0){
-        console.log("flaggedVariantCount = 0");
         this.$emit("flagged-variant-selected", null)
-
       }
     },
 

--- a/client/app/components/viz/Navigation.vue
+++ b/client/app/components/viz/Navigation.vue
@@ -1266,6 +1266,11 @@ export default {
     },
     onFlaggedVariantCountChanged: function(count) {
       this.flaggedVariantCount = count;
+      if(this.flaggedVariantCount === 0){
+        console.log("flaggedVariantCount = 0");
+        this.$emit("flagged-variant-selected", null)
+
+      }
     },
 
     onFilterSettingsApplied: function() {


### PR DESCRIPTION
When a user enters a phenotype and replaces the gene list, the variant-detail-card is updated to display the newly selected variant (or to not display if there are no variants in the replaced gene list)