### PR TITLE
Track rendering

### DIFF
--- a/client/app/components/viz/DepthViz.vue
+++ b/client/app/components/viz/DepthViz.vue
@@ -220,7 +220,10 @@ export default {
       },
       update: function() {
         var self = this;
-        if (self.data && self.data.length > 0 && self.data[0].length > 0) {
+
+        console.log("self.data in Depth-viz update", self.data);
+
+        if (self.data && self.data.length === 2000 && self.data[0].length > 0) {
           $(self.$el).removeClass("hide");
           self.depthChart.maxDepth(self.maxDepth);
           self.depthChart.xStart(self.regionStart);
@@ -232,9 +235,9 @@ export default {
 
 
         } else {
-          $(self.$el).addClass("hide");
-          var selection = d3.select(self.$el).datum( [[0,0]] );
-          self.depthChart(selection);
+          // $(self.$el).addClass("hide");
+          // var selection = d3.select(self.$el).datum( [[0,0]] );
+          // self.depthChart(selection);
         }
       },
       setDepthChart: function() {

--- a/client/app/components/viz/DepthViz.vue
+++ b/client/app/components/viz/DepthViz.vue
@@ -221,8 +221,6 @@ export default {
       update: function() {
         var self = this;
 
-        console.log("self.data in Depth-viz update", self.data);
-
         if (self.data && self.data.length === 2000 && self.data[0].length > 0) {
           $(self.$el).removeClass("hide");
           self.depthChart.maxDepth(self.maxDepth);
@@ -232,12 +230,6 @@ export default {
           self.depthChart.height(self.height);
           var selection = d3.select(self.$el).datum( self.data );
           self.depthChart(selection);
-
-
-        } else {
-          // $(self.$el).addClass("hide");
-          // var selection = d3.select(self.$el).datum( [[0,0]] );
-          // self.depthChart(selection);
         }
       },
       setDepthChart: function() {

--- a/client/app/components/viz/DepthViz.vue
+++ b/client/app/components/viz/DepthViz.vue
@@ -221,7 +221,7 @@ export default {
       update: function() {
         var self = this;
 
-        if (self.data && self.data.length === 2000 && self.data[0].length > 0) {
+        if (self.data && self.data.length > 1 && self.data[0].length > 0) {
           $(self.$el).removeClass("hide");
           self.depthChart.maxDepth(self.maxDepth);
           self.depthChart.xStart(self.regionStart);

--- a/client/app/components/viz/GeneViz.vue
+++ b/client/app/components/viz/GeneViz.vue
@@ -219,7 +219,6 @@
             this.regionSpan = this.regionStart + "-" + this.regionEnd;
 
             this.draw();
-            this.update();
         },
 
         methods: {
@@ -277,6 +276,7 @@
 
             update: function() {
                 var self = this;
+
                 if (self.data && self.data.length > 0 && self.data[0] != null && Object.keys(self.data[0]).length > 0) {
                     this.geneChart.regionStart(this.regionStart);
                     this.geneChart.regionEnd(this.regionEnd);
@@ -292,8 +292,14 @@
             },
         },
         watch: {
-            data: function() {
-                this.update();
+            data: function(oldData, newData) {
+
+                let bool = JSON.stringify(oldData) === JSON.stringify(newData);
+
+                if(!bool && newData) {
+                    console.log("oldData === newData and newData not null", bool);
+                    this.update();
+                }
             },
 
             regionStart: function() {
@@ -302,8 +308,10 @@
             regionEnd: function() {
                 this.regionSpan = this.regionStart + "-" + this.regionEnd;
             },
-            regionSpan: function() {
-                this.update();
+            regionSpan: function(oldRegion, newRegion) {
+                if(oldRegion !== newRegion) {
+                    this.update();
+                }
             }
         }
     }

--- a/client/app/components/viz/GeneViz.vue
+++ b/client/app/components/viz/GeneViz.vue
@@ -293,11 +293,8 @@
         },
         watch: {
             data: function(oldData, newData) {
-
                 let bool = JSON.stringify(oldData) === JSON.stringify(newData);
-
                 if(!bool && newData) {
-                    console.log("oldData === newData and newData not null", bool);
                     this.update();
                 }
             },

--- a/client/app/components/viz/VariantViz.vue
+++ b/client/app/components/viz/VariantViz.vue
@@ -198,7 +198,8 @@ export default {
       },
       update: function() {
         var self = this;
-        if (self.data) {
+
+        if (self.data && self.data.features.length > 0) {
 
           // Set the vertical layer count so that the height of the chart can be recalculated
           if (self.data.maxLevel == null) {


### PR DESCRIPTION
This PR fixes the unnecessary rendering of the depth-viz, gene-viz, and variant-viz components.  Before, when these tracks were loading, they would be rerendered when new genes were analyzed.  Whenever a new track is selected, all tracks would be reloaded.  Now, the gene-viz and variant-viz tracks are only re-rendered when there is a meaningful change in the data.  There is still a flicker of the depth-viz on load and when a new track is selected.  When this re-rendering occurs, there is an actual change in the data being passed into the depth-viz, so I could not check to see if the data changed to prevent this re-rendering.   This does, however, prevent the re-rendering of the depth-viz with null data.