### PR TITLE
fixed clivar significance not being saved when filter applied

### DIFF
--- a/client/app/components/partials/FilterSettings.vue
+++ b/client/app/components/partials/FilterSettings.vue
@@ -351,8 +351,6 @@ export default {
       this.minGenotypeDepth          = flagCriteria.minGenotypeDepth;
       this.minGenotypeAltCount       = flagCriteria.minGenotypeAltCount;
 
-
-
       this.$nextTick(function() {
         self.isDirty = false;
       })
@@ -375,6 +373,7 @@ export default {
       flagCriteria.key = this.key;
       flagCriteria.maxAf            = this.maxAf ? this.maxAf / 100 : null;
       flagCriteria.minRevel         = this.minRevel;
+      flagCriteria.clinvar =          this.selectedClinvarCategories;
       flagCriteria.impact           = this.selectedImpacts;
       flagCriteria.consequence      = this.selectedConsequences;
       flagCriteria.inheritance      = this.selectedInheritanceModes;


### PR DESCRIPTION
described issue from Al - "Ok. If I create a new filter and just set ClinVar significance to pathogenic then create the filter; the filter is created, but the clinvar significance requirement disappears, so basically all variants get dropped into the filter. If I edit the filter, I see that nothing is applied, so set pathogenic again, but it doesn't get applied"