### PR TITLE
Inheritance conservation hotfix

### DIFF
--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -1121,7 +1121,6 @@ export default {
   },
 
   watch: {
-
     isLeftDrawerOpen: function() {
       let self = this;
       setTimeout(function() {
@@ -2995,7 +2994,7 @@ export default {
                 self.$set(self, "selectedVariantKey", self.getVariantKey(flaggedVariant));
                 self.$set(self, "selectedVariantNotes", flaggedVariant.notes);
                 self.$set(self, "selectedVariantInterpretation", flaggedVariant.interpretation);
-                self.showVariantAssessment = false
+                self.showVariantAssessment = false;
 
                 self.showVariantExtraAnnots('proband', self.selectedVariant);
 

--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -1121,6 +1121,7 @@ export default {
   },
 
   watch: {
+
     isLeftDrawerOpen: function() {
       let self = this;
       setTimeout(function() {
@@ -2904,7 +2905,7 @@ export default {
     },
     onFlaggedVariantSelected: function(flaggedVariant, options={}, callback) {
       let self = this;
-      
+
       if(flaggedVariant === null){
         this.selectedVariant = null;
         return;
@@ -2994,7 +2995,7 @@ export default {
                 self.$set(self, "selectedVariantKey", self.getVariantKey(flaggedVariant));
                 self.$set(self, "selectedVariantNotes", flaggedVariant.notes);
                 self.$set(self, "selectedVariantInterpretation", flaggedVariant.interpretation);
-                self.showVariantAssessment = false;
+                self.showVariantAssessment = false
 
                 self.showVariantExtraAnnots('proband', self.selectedVariant);
 

--- a/client/app/components/partials/VariantInspectInheritanceRow.vue
+++ b/client/app/components/partials/VariantInspectInheritanceRow.vue
@@ -146,9 +146,6 @@ export default {
 
   filters: {
 
-
-
-
   },
 
   updated: function() {

--- a/client/app/components/partials/VariantInspectInheritanceRow.vue
+++ b/client/app/components/partials/VariantInspectInheritanceRow.vue
@@ -93,7 +93,6 @@
 
     <app-icon v-if="selectedVariant.inheritance.indexOf('n/a') == -1" :icon="selectedVariant.inheritance" style="margin-right:4px" width="16" height="16"></app-icon>
 
-    <!--v-if="selectedVariant.inheritance.indexOf('n/a') >= 0"-->
     <div  style="padding-bottom: 1px; padding-left: 4px">
     <span style="width:100px;line-height:14px">{{ selectedVariant.inheritance == 'denovo' ? 'de novo' : selectedVariant.inheritance }}</span>
     </div>

--- a/client/app/components/partials/VariantInspectInheritanceRow.vue
+++ b/client/app/components/partials/VariantInspectInheritanceRow.vue
@@ -93,7 +93,8 @@
 
     <app-icon v-if="selectedVariant.inheritance.indexOf('n/a') == -1" :icon="selectedVariant.inheritance" style="margin-right:4px" width="16" height="16"></app-icon>
 
-    <div v-if="selectedVariant.inheritance.indexOf('n/a') >= 0"  style="padding-bottom: 1px; padding-left: 4px">
+    <!--v-if="selectedVariant.inheritance.indexOf('n/a') >= 0"-->
+    <div  style="padding-bottom: 1px; padding-left: 4px">
     <span style="width:100px;line-height:14px">{{ selectedVariant.inheritance == 'denovo' ? 'de novo' : selectedVariant.inheritance }}</span>
     </div>
 
@@ -155,6 +156,7 @@ export default {
   },
 
   mounted: function() {
+
   },
 
   created: function() {

--- a/client/app/components/viz/VariantInspectCard.vue
+++ b/client/app/components/viz/VariantInspectCard.vue
@@ -950,7 +950,7 @@ export default {
         } else if (clazz == 'revel_moderate') {
           return 'level-medium';
         } else {
-          return 'wlevel-unremarkable';
+          return 'level-unremarkable';
         }
       } else {
         return 'level-unremarkable';

--- a/client/app/components/viz/VariantInspectCard.vue
+++ b/client/app/components/viz/VariantInspectCard.vue
@@ -950,7 +950,7 @@ export default {
         } else if (clazz == 'revel_moderate') {
           return 'level-medium';
         } else {
-          return 'level-unremarkable';
+          return 'wlevel-unremarkable';
         }
       } else {
         return 'level-unremarkable';
@@ -1608,6 +1608,16 @@ export default {
   },
 
   mounted: function() {
+      let self = this;
+      if(this.selectedVariant){
+          this.$nextTick(function() {
+              this.loadData();
+
+              if (self.selectedVariantRelationship === "known-variants") {
+                  self.annotateClinVarVariant(self.selectedVariant);
+              }
+          })
+      }
 
   },
 


### PR DESCRIPTION
Inheritance and conservations visualizations now properly render when gene is launched from standalone.  Inheritance labels now properly displayed when gene is launched from mosaic or from standalone.  Inheritance labels for gene when launched from clin needs to be fixed with a separate PR for clin.iobio.