### PR TITLE
recalculating strand orientaiton position based on region zoom

### DIFF
--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -3479,7 +3479,7 @@ export default {
               self.geneModel.setRankedGenes({'gtr': clinObject.gtrFullList, 'phenolyzer': clinObject.phenolyzerFullList })
               self.geneModel.setGenePhenotypeHitsFromClin(clinObject.genesReport);
             }
-            
+
             //Sets the current build from clinObject type set-data
             self.genomeBuildHelper.setCurrentBuild(clinObject.buildName);
 
@@ -3876,18 +3876,27 @@ export default {
           })
         })
 
-        if (firstFlaggedVariant) {
+        if (firstFlaggedVariant &&  getGeneName(firstFlaggedVariant) !==  self.selectedGene.gene_name) {
           self.promiseLoadGene(getGeneName(firstFlaggedVariant))
-          .then(function() {
+                  .then(function() {
+                    self.toClickVariant = firstFlaggedVariant;
+                    self.showLeftPanelWhenFlaggedVariants();
+                    self.onFlaggedVariantSelected(firstFlaggedVariant, {}, function() {
+                      resolve()
+                    })
+                  })
 
-            self.toClickVariant = firstFlaggedVariant;
-            self.showLeftPanelWhenFlaggedVariants();
-            self.onFlaggedVariantSelected(firstFlaggedVariant, {}, function() {
-              resolve()
-            })
+        }
+
+        else if(firstFlaggedVariant){
+          self.toClickVariant = firstFlaggedVariant;
+          self.showLeftPanelWhenFlaggedVariants();
+          self.onFlaggedVariantSelected(firstFlaggedVariant, {}, function() {
+            resolve()
           })
+        }
 
-        } else {
+        else {
           setTimeout(function() {
             self.showLeftPanelForGenes();
           },1000)

--- a/client/app/components/viz/VariantViz.vue
+++ b/client/app/components/viz/VariantViz.vue
@@ -319,6 +319,15 @@ export default {
         }
       },
 
+        data(){
+            if(this.showFilter){
+                this.intersectVariants();
+            }
+            else{
+                this.variants = this.data;
+            }
+        },
+
       regionStart(){
         this.update();
       },

--- a/client/app/d3/Gene.d3.js
+++ b/client/app/d3/Gene.d3.js
@@ -482,12 +482,33 @@ export default function geneD3() {
       .filter(function(f) { var ft = f.feature_type.toLowerCase(); return ft == 'utr' || ft == 'cds'})
       .sort(function(a,b) { return parseInt(a.start) - parseInt(b.start)});
 
-    for (var i=0; i < sorted.length-1; i++) {
-      var currSpan = parseInt(sorted[i+1].start) - parseInt(sorted[i].end);
-      if (span < currSpan) {
-        span = currSpan;
-        center = parseInt(sorted[i].end) + span/2;
+    sorted = sorted.filter(function(f){
+      return f.start >= geneD3_regionStart && f.end <= geneD3_regionEnd;
+    })
+
+    if(sorted.length > 1) {
+      for (var i = 0; i < sorted.length - 1; i++) {
+        var currSpan = parseInt(sorted[i + 1].start) - parseInt(sorted[i].end);
+        if (span < currSpan) {
+          span = currSpan;
+          center = parseInt(sorted[i].end) + span / 2;
+        }
       }
+    }
+
+    else if(sorted.length === 1){
+      let s = parseInt(sorted[0].start);
+      let e = parseInt(sorted[0].end);
+
+      if(s - geneD3_regionStart > geneD3_regionEnd - e){
+        center = (s + geneD3_regionStart)/2;
+      }
+      else{
+        center = (geneD3_regionEnd + e)/2;
+      }
+    }
+    else if(sorted.length === 0){
+      center =  geneD3_regionEnd - ((geneD3_regionEnd - geneD3_regionStart)/2);
     }
     d.center = center;
     return [d];

--- a/client/app/d3/Gene.d3.js
+++ b/client/app/d3/Gene.d3.js
@@ -483,16 +483,49 @@ export default function geneD3() {
       .sort(function(a,b) { return parseInt(a.start) - parseInt(b.start)});
 
     sorted = sorted.filter(function(f){
-      return f.start >= geneD3_regionStart && f.end <= geneD3_regionEnd;
+      return parseInt(f.start) >= geneD3_regionStart && parseInt(f.end) <= geneD3_regionEnd;
     })
+
+
+    let positions = [];
+
+    for(let i = 0; i < sorted.length; i++){
+      positions.push(parseInt(sorted[i].start));
+      positions.push(parseInt(sorted[i].end));
+    }
+    //todo: figure out direction before calculating left most and right most;
+
+    positions = positions.sort();
+    console.log("positions", positions);
+
+    let lm = null;
+    let rm = null;
+
+    if(positions.length > 0) {
+      lm = positions[0];
+      rm = positions.slice(-1)[0];
+    }
+
+    let edgeSpan = Math.max(lm - geneD3_regionStart, geneD3_regionEnd -rm);
+    let edgeCenter = null;
+
+    if(lm - geneD3_regionStart > geneD3_regionEnd -rm){
+      edgeCenter = (lm + geneD3_regionStart)/2
+    }
+    else{
+      edgeCenter = (rm + geneD3_regionEnd)/2;
+    }
 
     if(sorted.length > 1) {
       for (var i = 0; i < sorted.length - 1; i++) {
-        var currSpan = parseInt(sorted[i + 1].start) - parseInt(sorted[i].end);
+        let currSpan = parseInt(sorted[i + 1].start) - parseInt(sorted[i].end);
         if (span < currSpan) {
           span = currSpan;
           center = parseInt(sorted[i].end) + span / 2;
         }
+      }
+      if(edgeSpan > span){
+        center = edgeCenter;
       }
     }
 

--- a/client/app/d3/Gene.d3.js
+++ b/client/app/d3/Gene.d3.js
@@ -485,18 +485,13 @@ export default function geneD3() {
     sorted = sorted.filter(function(f){
       return parseInt(f.start) >= geneD3_regionStart && parseInt(f.end) <= geneD3_regionEnd;
     })
-
-
     let positions = [];
 
     for(let i = 0; i < sorted.length; i++){
       positions.push(parseInt(sorted[i].start));
       positions.push(parseInt(sorted[i].end));
     }
-    //todo: figure out direction before calculating left most and right most;
-
     positions = positions.sort();
-    console.log("positions", positions);
 
     let lm = null;
     let rm = null;


### PR DESCRIPTION
Recalculate gene-viz orientation when the region is updated with zoom.  For orientation center calculation, filter out all regions not contained within the zoom region.  If no regions are visible, orientation is in the middle of the region.  If only 1 region is visible, orientation is in the center of the largest empty region.