### PR TITLE
Clin var reload fix

### DIFF
--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -2330,6 +2330,7 @@ export default {
       if (viz) {
         self.cohortModel.knownVariantsViz = viz;
       }
+
       if (self.showKnownVariantsCard && self.cohortModel && self.cohortModel.isLoaded && Object.keys(self.selectedGene).length > 0) {
         self.cohortModel.promiseLoadKnownVariants(self.selectedGene, self.selectedTranscript);
       }
@@ -2339,8 +2340,12 @@ export default {
         if (viz) {
             self.cohortModel.sfariVariantsViz = viz;
         }
+
+        console.log("onSfariVariantsVizChange", viz);
+
         if (self.showSfariVariantsCard && self.cohortModel && self.cohortModel.isLoaded && Object.keys(self.selectedGene).length > 0
             && self.acmgBlacklist[self.selectedGene.gene_name] == null) {
+
             self.cohortModel.promiseLoadSfariVariants(self.selectedGene, self.selectedTranscript);
         }
     },
@@ -3479,7 +3484,7 @@ export default {
               self.geneModel.setRankedGenes({'gtr': clinObject.gtrFullList, 'phenolyzer': clinObject.phenolyzerFullList })
               self.geneModel.setGenePhenotypeHitsFromClin(clinObject.genesReport);
             }
-            
+
             //Sets the current build from clinObject type set-data
             self.genomeBuildHelper.setCurrentBuild(clinObject.buildName);
 
@@ -3926,7 +3931,7 @@ export default {
 
             if (self.clinSetData.analysis.payload.variants && self.clinSetData.analysis.payload.variants.length > 0 ) {
 
-              
+
               self.analysis.payload.variants.forEach(function(importedVariant) {
                 importedVariant.isImported = true;
               })

--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -3074,7 +3074,7 @@ export default {
         }
     },
     onOptionalTrackClose: function(showIt) {
-      this.promiseLoadGene(this.selectedGene.gene_name);
+      // this.promiseLoadGene(this.selectedGene.gene_name);
     },
     onShowMotherCard: function(showIt) {
       let self = this;

--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -2330,7 +2330,6 @@ export default {
       if (viz) {
         self.cohortModel.knownVariantsViz = viz;
       }
-
       if (self.showKnownVariantsCard && self.cohortModel && self.cohortModel.isLoaded && Object.keys(self.selectedGene).length > 0) {
         self.cohortModel.promiseLoadKnownVariants(self.selectedGene, self.selectedTranscript);
       }
@@ -2340,12 +2339,8 @@ export default {
         if (viz) {
             self.cohortModel.sfariVariantsViz = viz;
         }
-
-        console.log("onSfariVariantsVizChange", viz);
-
         if (self.showSfariVariantsCard && self.cohortModel && self.cohortModel.isLoaded && Object.keys(self.selectedGene).length > 0
             && self.acmgBlacklist[self.selectedGene.gene_name] == null) {
-
             self.cohortModel.promiseLoadSfariVariants(self.selectedGene, self.selectedTranscript);
         }
     },

--- a/client/app/components/partials/OptionalTracksMenu.vue
+++ b/client/app/components/partials/OptionalTracksMenu.vue
@@ -62,8 +62,7 @@
         Other tracks
       </v-btn>
 
-      <div class="optional-track
-      s" style="padding: 20px;" >
+      <div class="optional-tracks" style="padding: 20px;" >
 
         <div style="display:flex;flex-flow:column">
           <v-checkbox label="Mother" v-if="isMother"  v-model="showMotherCard"></v-checkbox>

--- a/client/app/components/partials/OptionalTracksMenu.vue
+++ b/client/app/components/partials/OptionalTracksMenu.vue
@@ -62,7 +62,8 @@
         Other tracks
       </v-btn>
 
-      <div class="optional-tracks" style="padding: 20px;" >
+      <div class="optional-track
+      s" style="padding: 20px;" >
 
         <div style="display:flex;flex-flow:column">
           <v-checkbox label="Mother" v-if="isMother"  v-model="showMotherCard"></v-checkbox>

--- a/client/app/components/viz/VariantViz.vue
+++ b/client/app/components/viz/VariantViz.vue
@@ -289,11 +289,10 @@ export default {
     },
     watch: {
       variants: function(oldVar, newVar) {
-          if(oldVar && oldVar.features && newVar && newVar.features && oldVar.features.length === 0 && newVar.features.length > 0){
-          }
-          else if(oldVar && oldVar.features && newVar && newVar.features){
-              this.update();
-          }
+        if(oldVar && oldVar.features && newVar && newVar.features && oldVar.features.length === 0 && newVar.features.length > 0){}
+        else if(oldVar && oldVar.features && newVar && newVar.features){
+          this.update();
+        }
       },
 
       selectedVariant: function(){
@@ -324,9 +323,7 @@ export default {
       },
 
       regionStart(){
-          console.log("change in region for relationship", this.model.relationship)
-
-          this.update();
+        this.update();
       },
       regionEnd(){
         this.update();

--- a/client/app/components/viz/VariantViz.vue
+++ b/client/app/components/viz/VariantViz.vue
@@ -288,8 +288,12 @@ export default {
       },
     },
     watch: {
-      variants: function(){
-        this.update();
+      variants: function(oldVar, newVar) {
+          if(oldVar && oldVar.features && newVar && newVar.features && oldVar.features.length === 0 && newVar.features.length > 0){
+          }
+          else if(oldVar && oldVar.features && newVar && newVar.features){
+              this.update();
+          }
       },
 
       selectedVariant: function(){
@@ -320,7 +324,9 @@ export default {
       },
 
       regionStart(){
-        this.update();
+          console.log("change in region for relationship", this.model.relationship)
+
+          this.update();
       },
       regionEnd(){
         this.update();

--- a/client/app/models/CohortModel.js
+++ b/client/app/models/CohortModel.js
@@ -923,7 +923,9 @@ class CohortModel {
 
   promiseLoadSfariVariants(theGene, theTranscript) {
       let self = this;
+3
 
+      console.log("promiseLoadSfariVariatns");
       if (self.sfariVariantsViz === 'variants') {
           return self._promiseLoadSfariVariants(theGene, theTranscript);
       } else  {

--- a/client/app/models/CohortModel.js
+++ b/client/app/models/CohortModel.js
@@ -923,9 +923,6 @@ class CohortModel {
 
   promiseLoadSfariVariants(theGene, theTranscript) {
       let self = this;
-3
-
-      console.log("promiseLoadSfariVariatns");
       if (self.sfariVariantsViz === 'variants') {
           return self._promiseLoadSfariVariants(theGene, theTranscript);
       } else  {


### PR DESCRIPTION
Prevents the re-rendering of variant tracks when optianalTracks menu is close, check if data changed in a meaningful way when updating variant-viz