### PR TITLE
adding check to prevent null value error when launched from clin

### DIFF
--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -3876,7 +3876,7 @@ export default {
           })
         })
 
-        if (firstFlaggedVariant &&  getGeneName(firstFlaggedVariant) !==  self.selectedGene.gene_name) {
+        if (self.launchedFromClin || (firstFlaggedVariant &&  getGeneName(firstFlaggedVariant) !== self.selectedGene.gene_name)) {
           self.promiseLoadGene(getGeneName(firstFlaggedVariant))
                   .then(function() {
                     self.toClickVariant = firstFlaggedVariant;
@@ -3935,7 +3935,7 @@ export default {
 
             if (self.clinSetData.analysis.payload.variants && self.clinSetData.analysis.payload.variants.length > 0 ) {
 
-              
+
               self.analysis.payload.variants.forEach(function(importedVariant) {
                 importedVariant.isImported = true;
               })
@@ -4062,7 +4062,7 @@ export default {
         } else {
 
           self.promiseUpdateAnalysisGenesData();
-          
+
           self.hubSession.promiseAddAnalysis(self.analysis.project_id, self.analysis)
           .then(function(analysis) {
             self.analysis = analysis;


### PR DESCRIPTION
Addressing issue mentioned in slack when trying to access a property of null when launched from clin