### PR TITLE
changing public gene clinVar url to point to iobio backend

### DIFF
--- a/client/app/globals/GlobalApp.js
+++ b/client/app/globals/GlobalApp.js
@@ -152,8 +152,8 @@ class GlobalApp {
 
 
         var clinvarUrls = {
-          'GRCh37': "ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/archive_2.0/2018/clinvar_20181202.vcf.gz",
-          'GRCh38': "ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/archive_2.0/2018/clinvar_20181202.vcf.gz",
+          'GRCh37': "https://backend.iobio.io/static/clinvar/GRCh37/clinvar.vcf.gz",
+          'GRCh38': "https://backend.iobio.io/static/clinvar/GRCh38/clinvar.vcf.gz"
         };
         return clinvarUrls[build];
 


### PR DESCRIPTION
Keeping logic in place to detect if launched from mosaic for when we want to switch over to use Mosaic clinvar links.  Using iobio backend clinVar links in public gene for consistency, and tested stability. 

("If geneinfo and genomebuild are still pointed at backend.iobio.io, it might be best to keep the ClinVar stuff pointed there for consistency. Eventually we should get everything pointed into the PE though I think" - Anders)