### PR TITLE
Pedigree overlap

### DIFF
--- a/client/app/components/viz/VariantInspectCard.vue
+++ b/client/app/components/viz/VariantInspectCard.vue
@@ -299,7 +299,7 @@
         opacity: .65
 
       text
-        font-size: 11px
+        font-size: 9px
         text-anchor: middle
 
 #show-more-gene-association-button

--- a/client/app/d3/PedigreeGenotypeChart.d3.js
+++ b/client/app/d3/PedigreeGenotypeChart.d3.js
@@ -209,7 +209,7 @@ export default function PedigreeGenotypeChartD3() {
         nodeData.altRatio = 1;
     }
 
-      //todo: refactor redundant code in if statement
+    //todo: refactor redundant code in if statement
 
     if (nodeData.totalCount != null && nodeData.altCount != null) {
         let group = parent.append("g")
@@ -271,7 +271,6 @@ export default function PedigreeGenotypeChartD3() {
                 .text(function (d, i) {
                     return nodeData.altCount + " alt, " + (nodeData.totalCount - nodeData.altCount) + ' ref';
                 })
-
         }
   }
 

--- a/client/app/d3/PedigreeGenotypeChart.d3.js
+++ b/client/app/d3/PedigreeGenotypeChart.d3.js
@@ -209,6 +209,9 @@ export default function PedigreeGenotypeChartD3() {
         nodeData.altRatio = 1;
     }
 
+    nodeData.altCount = 888;
+    nodeData.totalCount = 1776;
+
       //todo: refactor redundant code in if statement
 
     if (nodeData.totalCount != null && nodeData.altCount != null) {
@@ -249,20 +252,18 @@ export default function PedigreeGenotypeChartD3() {
                 .attr("height", 5)
 
             group.append("text")
-                .attr("x", (nodeWidth + 20) / 2)
+                .attr("x", function (d, i) {
+                    if (position == "top") {
+                        return (nodeWidth + 20) / 2
+                    } else {
+                        return (nodeWidth + 26) / 2
+                    }
+                })
                 .attr("y", function (d, i) {
                     if (position == "top") {
                         return -5;
                     } else {
                         return 16;
-                    }
-                })
-                .style("font-size", d => {
-                    if(nodeData.altCount > 99 || nodeData.totalCount - nodeData.altCount > 99){
-                        return "8px";
-                    }
-                    else{
-                        return "11px";
                     }
                 })
                 .text(function (d, i) {

--- a/client/app/d3/PedigreeGenotypeChart.d3.js
+++ b/client/app/d3/PedigreeGenotypeChart.d3.js
@@ -253,7 +253,12 @@ export default function PedigreeGenotypeChartD3() {
                     if (position == "top") {
                         return (nodeWidth + 20) / 2
                     } else {
-                        return (nodeWidth + 26) / 2
+                        if(nodeData.altCount > 99 || nodeData.totalCount - nodeData.altCount > 99) {
+                            return (nodeWidth + 26) / 2
+                        }
+                        else{
+                            return (nodeWidth + 20) / 2
+                        }
                     }
                 })
                 .attr("y", function (d, i) {

--- a/client/app/d3/PedigreeGenotypeChart.d3.js
+++ b/client/app/d3/PedigreeGenotypeChart.d3.js
@@ -209,7 +209,7 @@ export default function PedigreeGenotypeChartD3() {
         nodeData.altRatio = 1;
     }
 
-    //todo: refactor redundant code in if statement
+      //todo: refactor redundant code in if statement
 
     if (nodeData.totalCount != null && nodeData.altCount != null) {
         let group = parent.append("g")
@@ -257,9 +257,18 @@ export default function PedigreeGenotypeChartD3() {
                         return 16;
                     }
                 })
+                .style("font-size", d => {
+                    if(nodeData.altCount > 99 || nodeData.totalCount - nodeData.altCount > 99){
+                        return "8px";
+                    }
+                    else{
+                        return "11px";
+                    }
+                })
                 .text(function (d, i) {
                     return nodeData.altCount + " alt, " + (nodeData.totalCount - nodeData.altCount) + ' ref';
                 })
+
         }
   }
 

--- a/client/app/d3/PedigreeGenotypeChart.d3.js
+++ b/client/app/d3/PedigreeGenotypeChart.d3.js
@@ -209,9 +209,6 @@ export default function PedigreeGenotypeChartD3() {
         nodeData.altRatio = 1;
     }
 
-    nodeData.altCount = 888;
-    nodeData.totalCount = 1776;
-
       //todo: refactor redundant code in if statement
 
     if (nodeData.totalCount != null && nodeData.altCount != null) {


### PR DESCRIPTION
Reducing font size - positioning bottom row text conditional on digit length to ensure that 3 digit worst case scenario (888 alt, 888 ref) isn't cut off.

To test: go to project 111 and launch gene with the 'Filtered Candidates' variant set.  Click on a bunch of different variants and make sure that the pedigree ref/alt count text looks nice on all cases (1 digit, 2 digit, 3 digit, mixed digits)