### PR TITLE
Will gene 4.3.6

### DIFF
--- a/client/app/components/partials/VariantInspectInheritanceRow.vue
+++ b/client/app/components/partials/VariantInspectInheritanceRow.vue
@@ -83,7 +83,7 @@
 </style>
 
 <template>
-  <div class="variant-row">
+  <div v-if="selectedVariant.inheritance.indexOf('n/a') == -1" class="variant-row">
     <v-icon v-if="selectedVariant.inheritance.indexOf('n/a') == -1" class="level-high">
       check_circle
     </v-icon>

--- a/client/app/components/viz/GeneVariantsCard.vue
+++ b/client/app/components/viz/GeneVariantsCard.vue
@@ -205,7 +205,8 @@
             },
             onGeneRegionBufferChange: _.debounce(function (newGeneRegionBuffer) {
                 this.regionBuffer = Math.min(parseInt(newGeneRegionBuffer), 99999);
-                this.$emit('gene-region-buffer-change', this.regionBuffer);            }, 100),
+                this.$emit('gene-region-buffer-change', this.regionBuffer);
+            }, 100),
             onClickTranscript: function(link) {
             },
             onTranscriptSelected: function(transcript) {

--- a/client/app/components/viz/GeneVariantsCard.vue
+++ b/client/app/components/viz/GeneVariantsCard.vue
@@ -128,7 +128,7 @@
                 <v-badge id="minus-strand"   class="info" style="margin-left:3px;margin-right:10px" v-if="selectedGene.strand == '-'">reverse strand</v-badge>
 
                 <span  id="gene-plus-minus-label"  v-if="!isBasicMode && !isSimpleMode"  style="padding-left: 15px">+  -</span>
-                <div id="region-buffer-box" v-if="!isBasicMode && !isSimpleMode" style="display:inline-block;width:40px;height:21px;"  >
+                <div id="region-buffer-box" v-if="!isBasicMode && !isSimpleMode" style="display:inline-block;width:50px;height:21px;"  >
                     <v-text-field
                             id="gene-region-buffer-input"
                             class="sm fullview"
@@ -204,8 +204,8 @@
                 }
             },
             onGeneRegionBufferChange: _.debounce(function (newGeneRegionBuffer) {
-                this.$emit('gene-region-buffer-change', parseInt(newGeneRegionBuffer));
-            }, 100),
+                this.regionBuffer = Math.min(parseInt(newGeneRegionBuffer), 99999);
+                this.$emit('gene-region-buffer-change', this.regionBuffer);            }, 100),
             onClickTranscript: function(link) {
             },
             onTranscriptSelected: function(transcript) {

--- a/client/app/components/viz/VariantInspectCard.vue
+++ b/client/app/components/viz/VariantInspectCard.vue
@@ -18,7 +18,7 @@
     white-space: normal
     display: inline-block
     word-break: break-all
-    min-width: 100px 
+    min-width: 100px
 
   .aa-change
     max-width: 200px
@@ -299,7 +299,7 @@
         opacity: .65
 
       text
-        font-size: 11px
+        font-size: 9px
         text-anchor: middle
 
 #show-more-gene-association-button

--- a/client/app/components/viz/VariantInspectCard.vue
+++ b/client/app/components/viz/VariantInspectCard.vue
@@ -576,16 +576,16 @@
 
       <div class="variant-inspect-column" v-if="selectedVariant">
           <div class="variant-column-header">
-              {{ isSimpleMode ? 'Population Frequency' : 'Pop Freq in gnomAD' }}
+              {{ isSimpleMode ? 'Population Frequency' : 'gnomAD' }}
             <info-popup v-if="!isSimpleMode" name="gnomAD"></info-popup>
             <v-divider></v-divider>
           </div>
           <div class="variant-column-hint" v-if="isSimpleMode">
             Common variants typically don’t cause diseases.
           </div>
-          <variant-inspect-row :clazz="afGnomAD.class" :value="afGnomAD.percent" :label="`Allele freq`" :link="afGnomAD.link" >
+          <variant-inspect-row :clazz="afGnomAD.class" :value="afGnomAD.percent" :label="`Allele frequency`" :link="afGnomAD.link" >
           </variant-inspect-row>
-          <variant-inspect-row v-if="!isSimpleMode && afGnomAD.percentPopMax" :clazz="afGnomAD.class" :value="afGnomAD.percentPopMax" :label="`Pop max allele freq`" >
+          <variant-inspect-row v-if="!isSimpleMode && afGnomAD.percentPopMax" :clazz="afGnomAD.class" :value="afGnomAD.percentPopMax" :label="`Population max allele frequency`" >
           </variant-inspect-row>
           <div v-if="!isSimpleMode && afGnomAD.totalCount > 0" class="variant-row no-icon">
             <span>{{ afGnomAD.altCount }} alt of {{ afGnomAD.totalCount }} total</span>

--- a/client/app/d3/PedigreeGenotypeChart.d3.js
+++ b/client/app/d3/PedigreeGenotypeChart.d3.js
@@ -249,7 +249,18 @@ export default function PedigreeGenotypeChartD3() {
                 .attr("height", 5)
 
             group.append("text")
-                .attr("x", (nodeWidth + 20) / 2)
+                .attr("x", function (d, i) {
+                    if (position == "top") {
+                        return (nodeWidth + 20) / 2
+                    } else {
+                        if(nodeData.altCount > 99 || nodeData.totalCount - nodeData.altCount > 99) {
+                            return (nodeWidth + 26) / 2
+                        }
+                        else{
+                            return (nodeWidth + 20) / 2
+                        }
+                    }
+                })
                 .attr("y", function (d, i) {
                     if (position == "top") {
                         return -5;

--- a/client/app/models/GeneModel.js
+++ b/client/app/models/GeneModel.js
@@ -1169,7 +1169,8 @@ class GeneModel {
     if (geneObject) {
       geneCoord = geneObject.chr + ":" + geneObject.start + "-" + geneObject.end;
     }
-
+    me.promiseGetNCBIGeneSummary(geneName);
+    
     var buildAliasUCSC = me.genomeBuildHelper.getBuildAlias('UCSC');
 
     var geneUID = null;

--- a/client/app/models/GeneModel.js
+++ b/client/app/models/GeneModel.js
@@ -14,6 +14,7 @@ class GeneModel {
         omim:      { display: 'OMIM',      url: 'https://www.omim.org/search/?search=GENESYMBOL'},
         humanmine: { display: 'HumanMine', url: 'http://www.humanmine.org/humanmine/keywordSearchResults.do?searchTerm=+GENESYMBOL&searchSubmit=GO'},
         ncbi:      { display: 'NCBI',      url: 'https://www.ncbi.nlm.nih.gov/gene/GENEUID'},
+        pubmed:    { display: 'PubMed',    url: 'https://pubmed.ncbi.nlm.nih.gov/?from_uid=GENEUID&linkname=gene_pubmed'},
         decipher:  { display: 'DECIPHER',  url: 'https://decipher.sanger.ac.uk/search?q=GENESYMBOL'},
         marrvel:   { display: 'MARRVEL',   url: 'http://marrvel.org/search/gene/GENESYMBOL'},
         genecards: { display: 'GeneCards', url: 'https://www.genecards.org/cgi-bin/carddisp.pl?gene=GENESYMBOL'},
@@ -1170,7 +1171,7 @@ class GeneModel {
       geneCoord = geneObject.chr + ":" + geneObject.start + "-" + geneObject.end;
     }
     me.promiseGetNCBIGeneSummary(geneName);
-    
+
     var buildAliasUCSC = me.genomeBuildHelper.getBuildAlias('UCSC');
 
     var geneUID = null;


### PR DESCRIPTION
Emergency fixes for 4.3.6
1) alt/ref pedigree clipping on triple-digit counts
2) NCBI broken link
3) PubMed link
4) up/downstream clipping and limit region buffer BP to 99,999
5) gnomAd title and pop/freq replaced with full words
6) Removed text and glyph from pedigree inheritance title for any n/a inheritance