### PR TITLE
Sibling entry

### DIFF
--- a/client/app/components/partials/FilesDialog.vue
+++ b/client/app/components/partials/FilesDialog.vue
@@ -230,7 +230,7 @@
                   siblings
                 </span>
                 <span class="siblings-disabled" v-if="!(probandSamples && probandSamples.length > 0)" >
-                 **Upload a vcf with more than 1 sample to enable sibling selection
+                 **Proband vcf must contain sibling data to enable sibling selection
                </span>
                </v-flex>
                 <v-flex  class=" pl-2 pr-3" >

--- a/client/app/components/partials/FilesDialog.vue
+++ b/client/app/components/partials/FilesDialog.vue
@@ -109,10 +109,9 @@
       margin-top: 0px
 
   .siblings-disabled
-      font-size: 13px
-      color: rgba(0,0,0,0.54)
-      padding-top: 2px
-
+      font-size: 13px !important
+      color: $text-color !important
+      padding-top: 2px !important
 </style>
 
 <template>
@@ -225,14 +224,14 @@
 
             <v-layout row no-wrap class="pr-2 pb-4 pt-3">
 
-               <v-flex  class="sample-label mt-3 pl-2 pr-3" >
+               <v-flex  class="sample-label mt-3 pl-2 pr-2" >
                 <span
                  dark small >
                   siblings
                 </span>
-                   <span class="siblings-disabled" v-if="!(probandSamples && probandSamples.length > 0)" >
-                       **Upload a vcf with more than 1 sample to enable sibling selection
-                   </span>
+                <span class="siblings-disabled" v-if="!(probandSamples && probandSamples.length > 0)" >
+                 **Upload a vcf with more than 1 sample to enable sibling selection
+               </span>
                </v-flex>
                 <v-flex  class=" pl-2 pr-3" >
                  <v-autocomplete
@@ -422,9 +421,11 @@ export default {
     },
     checkForDuplicates: function(sms){
       let self = this;
-      sms.map(function(obj) {
+      let names = sms.map(function(obj) {
         return obj.name;
-      }).forEach(function (element, index, arr) {
+      }).concat(self.affectedSibs, self.unaffectedSibs);
+
+      names.forEach(function (element, index, arr) {
         if (arr.indexOf(element) !== index) {
           self.errorTitle = "Duplicate Ids";
           let errorMsg = "Duplicate ids detected for " + element;

--- a/client/app/components/partials/FilesDialog.vue
+++ b/client/app/components/partials/FilesDialog.vue
@@ -108,6 +108,11 @@
       margin-bottom: 10px
       margin-top: 0px
 
+  .siblings-disabled
+      font-size: 13px
+      color: rgba(0,0,0,0.54)
+      padding-top: 2px
+
 </style>
 
 <template>
@@ -218,19 +223,23 @@
 
             </v-layout >
 
-            <v-layout row nowrap class="mt-2">
+            <v-layout row no-wrap class="pr-2 pb-4 pt-3">
 
                <v-flex  class="sample-label mt-3 pl-2 pr-3" >
-                <span v-if="probandSamples && probandSamples.length > 0"
+                <span
                  dark small >
                   siblings
                 </span>
+                   <span class="siblings-disabled" v-if="!(probandSamples && probandSamples.length > 0)" >
+                       **Upload a vcf with more than 1 sample to enable sibling selection
+                   </span>
                </v-flex>
 
-               <v-flex  class=" pl-2 pr-3" >
+                <!--v-bind:class="probandSamples == null || probandSamples.length == 0 ? 'hide' : ''"-->
+
+                <v-flex  class=" pl-2 pr-3" >
                  <v-autocomplete
-                  v-if="probandSamples && probandSamples.length > 0"
-                  v-bind:class="probandSamples == null || probandSamples.length == 0 ? 'hide' : ''"
+                  v-bind:disabled="!(probandSamples && probandSamples.length > 0)"
                   label="Affected Siblings"
                   multiple
                   v-model="affectedSibs"
@@ -242,8 +251,7 @@
 
                <v-flex   class="pr-2">
                  <v-autocomplete
-                  v-if="probandSamples && probandSamples.length > 0"
-                  v-bind:class="probandSamples == null || probandSamples.length == 0 ? 'hide' : ''"
+                  v-bind:disabled="!(probandSamples && probandSamples.length > 0)"
                   label="Unaffected Siblings"
                   multiple
                   v-model="unaffectedSibs"
@@ -265,49 +273,49 @@ import SampleData          from '../partials/SampleData.vue'
 
 
 export default {
-  name: 'files-dialog',
-  components: {
-    SampleData
-  },
-  props: {
-    cohortModel: null,
-    showDialog: null
-  },
-  data () {
-    return {
-      showFilesDialog: false,
-      isValid: false,
-      areAnyDuplicates: false,
-      loadReady: true,
-      warningOpen: false,
-      errorMsgArray: [],
-      errorTitle: "",
-      mode: 'single',
-      speciesList: [],
-      speciesName: null,
-      buildName: null,
-      activeTab: null,
-      modelInfoMap: {
-        proband: {},
-        mother: {},
-        father: {}
-      },
-      rels: {
-        single: ['proband'],
-        trio: ['proband', 'mother', 'father']
-      },
-      demoActions: [
-        {'display': 'Demo WES trio', 'value': 'exome'},
-        {'display': 'Demo WGS trio', 'value': 'genome'}
-      ],
-      demoAction: null,
-      separateUrlForIndex: false,
-      probandSamples: null,
-      affectedSibs: null,
-      unaffectedSibs: null,
-      inProgress: false
-    }
-  },
+    name: 'files-dialog',
+    components: {
+        SampleData
+    },
+    props: {
+        cohortModel: null,
+        showDialog: null
+    },
+    data() {
+        return {
+            showFilesDialog: false,
+            isValid: false,
+            areAnyDuplicates: false,
+            loadReady: true,
+            warningOpen: false,
+            errorMsgArray: [],
+            errorTitle: "",
+            mode: 'single',
+            speciesList: [],
+            speciesName: null,
+            buildName: null,
+            activeTab: null,
+            modelInfoMap: {
+                proband: {},
+                mother: {},
+                father: {}
+            },
+            rels: {
+                single: ['proband'],
+                trio: ['proband', 'mother', 'father']
+            },
+            demoActions: [
+                {'display': 'Demo WES trio', 'value': 'exome'},
+                {'display': 'Demo WGS trio', 'value': 'genome'}
+            ],
+            demoAction: null,
+            separateUrlForIndex: false,
+            probandSamples: null,
+            affectedSibs: null,
+            unaffectedSibs: null,
+            inProgress: false
+        }
+    },
   watch: {
     loadReady: function(){
       let self = this;

--- a/client/app/components/partials/FilesDialog.vue
+++ b/client/app/components/partials/FilesDialog.vue
@@ -234,9 +234,6 @@
                        **Upload a vcf with more than 1 sample to enable sibling selection
                    </span>
                </v-flex>
-
-                <!--v-bind:class="probandSamples == null || probandSamples.length == 0 ? 'hide' : ''"-->
-
                 <v-flex  class=" pl-2 pr-3" >
                  <v-autocomplete
                   v-bind:disabled="!(probandSamples && probandSamples.length > 0)"
@@ -273,49 +270,49 @@ import SampleData          from '../partials/SampleData.vue'
 
 
 export default {
-    name: 'files-dialog',
-    components: {
-        SampleData
-    },
-    props: {
-        cohortModel: null,
-        showDialog: null
-    },
-    data() {
-        return {
-            showFilesDialog: false,
-            isValid: false,
-            areAnyDuplicates: false,
-            loadReady: true,
-            warningOpen: false,
-            errorMsgArray: [],
-            errorTitle: "",
-            mode: 'single',
-            speciesList: [],
-            speciesName: null,
-            buildName: null,
-            activeTab: null,
-            modelInfoMap: {
-                proband: {},
-                mother: {},
-                father: {}
-            },
-            rels: {
-                single: ['proband'],
-                trio: ['proband', 'mother', 'father']
-            },
-            demoActions: [
-                {'display': 'Demo WES trio', 'value': 'exome'},
-                {'display': 'Demo WGS trio', 'value': 'genome'}
-            ],
-            demoAction: null,
-            separateUrlForIndex: false,
-            probandSamples: null,
-            affectedSibs: null,
-            unaffectedSibs: null,
-            inProgress: false
-        }
-    },
+  name: 'files-dialog',
+  components: {
+    SampleData
+  },
+  props: {
+    cohortModel: null,
+    showDialog: null
+  },
+  data() {
+    return {
+      showFilesDialog: false,
+      isValid: false,
+      areAnyDuplicates: false,
+      loadReady: true,
+      warningOpen: false,
+      errorMsgArray: [],
+      errorTitle: "",
+      mode: 'single',
+      speciesList: [],
+      speciesName: null,
+      buildName: null,
+      activeTab: null,
+      modelInfoMap: {
+        proband: {},
+        mother: {},
+        father: {}
+      },
+      rels: {
+        single: ['proband'],
+        trio: ['proband', 'mother', 'father']
+      },
+      demoActions: [
+        {'display': 'Demo WES trio', 'value': 'exome'},
+        {'display': 'Demo WGS trio', 'value': 'genome'}
+      ],
+      demoAction: null,
+      separateUrlForIndex: false,
+      probandSamples: null,
+      affectedSibs: null,
+      unaffectedSibs: null,
+      inProgress: false
+    }
+  },
   watch: {
     loadReady: function(){
       let self = this;


### PR DESCRIPTION
On user upload, disable sibling selection if vcf only contains 1 sample id, and have error message explaining why sibling selection is disabled, sibling selection styling improvements.