### PR TITLE
updaing variant set api call to include gene symbol information

### DIFF
--- a/client/app/models/HubSession.js
+++ b/client/app/models/HubSession.js
@@ -809,8 +809,11 @@ export default class HubSession {
     let self = this;
 
     return $.ajax({
-      url: self.apiDepricated + '/projects/' + projectId + '/variants?variant_set_id=' + variantSetId + "&include_variant_data=true",
-
+      url: self.apiDepricated + '/projects/' + projectId + '/variants?variant_set_id=' + variantSetId,
+      data: {
+        include_variant_data: true,
+        annotation_uids: ['gene_symbol'],
+      },
       type: 'GET',
       contentType: 'application/json',
       headers: {


### PR DESCRIPTION
Updating variantSet API call to reflect changes made to Mosaic backend.  This API call includes the gene_symbol annotation for variants, fixing the error when launching from variant sets.