### PR TITLE
Zoom selected variant

### DIFF
--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -2162,6 +2162,8 @@ export default {
       this.cohortModel.setCoverage(this.geneRegionStart, this.geneRegionEnd);
     },
     onGeneRegionZoomReset: function() {
+      console.log("onGeneRegionZoomReset");
+      this.showZoom = false;
       this.geneRegionStart = this.selectedGene.start;
       this.geneRegionEnd = this.selectedGene.end;
 

--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -2162,7 +2162,6 @@ export default {
       this.cohortModel.setCoverage(this.geneRegionStart, this.geneRegionEnd);
     },
     onGeneRegionZoomReset: function() {
-      console.log("onGeneRegionZoomReset");
       this.showZoom = false;
       this.geneRegionStart = this.selectedGene.start;
       this.geneRegionEnd = this.selectedGene.end;

--- a/client/app/components/viz/VariantViz.vue
+++ b/client/app/components/viz/VariantViz.vue
@@ -205,11 +205,7 @@ export default {
       },
       update: function() {
         var self = this;
-
-        console.log("update");
-
         if (self.variants && self.data.features) {
-          console.log("update if");
             // Set the vertical layer count so that the height of the chart can be recalculated
           if (self.variants.maxLevel == null) {
             self.variants.maxLevel = d3.max(self.variants.features, function(d) { return d.level; });
@@ -226,6 +222,7 @@ export default {
           self.variantChart.regionEnd(self.regionEnd);
 
           self.variantChart.width(self.width);
+          self.variantChart.selectedVariant(self.selectedVariant);
 
 
           var selection = d3.select(self.$el).datum( [self.variants] );
@@ -283,14 +280,13 @@ export default {
             if(variant){
 
             if(variant.start !== v.start ||
-            variant.ref !== v.ref ||
-            variant.alt !== v.alt){
-              isEqual = false;
-            }
+              variant.ref !== v.ref ||
+              variant.alt !== v.alt){
+                isEqual = false;
+              }
             }
           }
-      }
-        console.log("isEqual", isEqual);
+        }
         return isEqual;
       },
 
@@ -316,18 +312,13 @@ export default {
     watch: {
       variants: function(oldVar, newVar) {
         if(oldVar && oldVar.features && newVar && newVar.features){
-          console.log("oldVar.features", oldVar.features, newVar.features);
-          // if(JSON.stringify(oldVar.features) !== JSON.stringify(newVar.features)) {
           if(! this.isEqual(oldVar.features, newVar.features)){
-
-            console.log("variants watcher update", oldVar, newVar, "swag");
             this.update();
           }
         }
       },
 
       selectedVariant: function(){
-        console.log("selectedVariantWatcher");
         if(this.showFilter){
           this.intersectVariants();
         }
@@ -367,11 +358,9 @@ export default {
         },
 
       regionStart(){
-        console.log("region start update");
         this.update();
       },
       regionEnd(){
-        console.log("region end update");
         this.update();
       }
     }

--- a/client/app/components/viz/VariantViz.vue
+++ b/client/app/components/viz/VariantViz.vue
@@ -206,7 +206,10 @@ export default {
       update: function() {
         var self = this;
 
+        console.log("update");
+
         if (self.variants && self.data.features) {
+          console.log("update if");
             // Set the vertical layer count so that the height of the chart can be recalculated
           if (self.variants.maxLevel == null) {
             self.variants.maxLevel = d3.max(self.variants.features, function(d) { return d.level; });
@@ -270,6 +273,28 @@ export default {
         this.variantChart.showFlaggedVariant(container, variant);
       },
 
+      isEqual: function(a, b) {
+        let isEqual = false
+        if(a.length === b.length) {
+          isEqual = true;
+          for (let i = 0; i < a.length; i++) {
+            let variant = a[i];
+            let v = b[i];
+            if(variant){
+
+            if(variant.start !== v.start ||
+            variant.ref !== v.ref ||
+            variant.alt !== v.alt){
+              isEqual = false;
+            }
+            }
+          }
+      }
+        console.log("isEqual", isEqual);
+        return isEqual;
+      },
+
+
       intersectVariants(){
           let copyVariants = Object.assign({}, this.filteredVariants);
           let features = [];
@@ -291,11 +316,18 @@ export default {
     watch: {
       variants: function(oldVar, newVar) {
         if(oldVar && oldVar.features && newVar && newVar.features){
-          this.update();
+          console.log("oldVar.features", oldVar.features, newVar.features);
+          // if(JSON.stringify(oldVar.features) !== JSON.stringify(newVar.features)) {
+          if(! this.isEqual(oldVar.features, newVar.features)){
+
+            console.log("variants watcher update", oldVar, newVar, "swag");
+            this.update();
+          }
         }
       },
 
       selectedVariant: function(){
+        console.log("selectedVariantWatcher");
         if(this.showFilter){
           this.intersectVariants();
         }
@@ -335,9 +367,11 @@ export default {
         },
 
       regionStart(){
+        console.log("region start update");
         this.update();
       },
       regionEnd(){
+        console.log("region end update");
         this.update();
       }
     }

--- a/client/app/d3/Variant.d3.js
+++ b/client/app/d3/Variant.d3.js
@@ -31,7 +31,8 @@ export default function variantD3() {
       lowestWidth = 3,
       dividerLevel = null,
       container = null,
-      clazz = null;
+      clazz = null,
+      selectedVariant = null;
 
   //  options
   var defaults = {};
@@ -67,8 +68,6 @@ export default function variantD3() {
           } else {
             matchingVariant = variant;
           }
-
-
        }
     });
 
@@ -383,9 +382,6 @@ export default function variantD3() {
         if (showBrush) {
           if (brushHeight == null ) {
             brushHeight = variantHeight;
-            brushY = 0;
-          } else {
-            brushY = 0;
           }
           track.selectAll("g.x.brush").data([0]).enter().append("g")
               .attr("class", "x brush")
@@ -616,6 +612,7 @@ export default function variantD3() {
 
 
 
+        showCircle(selectedVariant, svg, false, true);
 
         dispatch.d3rendered();
 
@@ -753,13 +750,6 @@ export default function variantD3() {
     return chart;
   };
 
-  chart.yAxis = function(_) {
-    if (!arguments.length) return yAxis;
-    yAxis = _;
-    return chart;
-  };
-
-
   chart.variantHeight = function(_) {
     if (!arguments.length) return variantHeight;
     variantHeight = _;
@@ -787,6 +777,11 @@ export default function variantD3() {
   chart.showXAxis = function(_) {
     if (!arguments.length) return showXAxis;
     showXAxis = _;
+    return chart;
+  };
+  chart.selectedVariant = function(_) {
+    if (!arguments.length) return selectedVariant;
+    selectedVariant = _;
     return chart;
   };
 
@@ -862,13 +857,6 @@ export default function variantD3() {
     hideCircle = _;
     return chart;
   }
-  chart.highlightVariant = function(_) {
-    if (!arguments.length) return highlightVariant;
-    highlightVariant = _;
-    return chart;
-  }
-
-
 
   // This adds the "on" methods to our custom exports
   d3.rebind(chart, dispatch, "on");

--- a/client/app/d3/Variant.d3.js
+++ b/client/app/d3/Variant.d3.js
@@ -612,7 +612,9 @@ export default function variantD3() {
 
 
 
-        showCircle(selectedVariant, svg, false, true);
+        if(selectedVariant) {
+          showCircle(selectedVariant, svg, false, true);
+        }
 
         dispatch.d3rendered();
 


### PR DESCRIPTION
Consistent selected variant state across zooming. Variants should not be deselected when the gene-viz is zoomed, and variants can now be selected when the track is zoomed in.