### PR TITLE
increasing duration of Enter gene message, making window close-able

### DIFF
--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -1323,7 +1323,7 @@ export default {
               } else {
                 if  (self.launchedWithUrlParms && self.geneModel.sortedGeneNames.length === 0 ) {
                   let theMessage = self.isSimpleMode || self.isBasicMode ? 'Enter a gene name.' : 'Enter a gene name or enter a phenotype term.'
-                  self.onShowSnackbar( {message: theMessage, timeout: 10000, closeable: true});
+                  self.onShowSnackbar( {message: theMessage, timeout: 10000, close: true});
                   self.bringAttention = 'gene';
                 }
 
@@ -1574,7 +1574,7 @@ export default {
               })
             } else {
               let theMessage = self.isSimpleMode || self.isBasicMode ? 'Enter a gene name.' : 'Enter a gene name or enter a phenotype term.'
-              self.onShowSnackbar( {message: theMessage, timeout: 10000, closeable: true});
+              self.onShowSnackbar( {message: theMessage, timeout: 10000, close: true});
               self.bringAttention = 'gene';
               resolve();
             }
@@ -1824,7 +1824,7 @@ export default {
           }
         } else {
           let theMessage = self.isSimpleMode || self.isBasicMode ? 'Enter a gene name.' : 'Enter a gene name or enter a phenotype term.'
-          self.onShowSnackbar( {message: theMessage, timeout: 10000, closeable: true});
+          self.onShowSnackbar( {message: theMessage, timeout: 10000, close: true});
           self.bringAttention = 'gene';
           if (callback) {
             callback();

--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -1323,7 +1323,7 @@ export default {
               } else {
                 if  (self.launchedWithUrlParms && self.geneModel.sortedGeneNames.length === 0 ) {
                   let theMessage = self.isSimpleMode || self.isBasicMode ? 'Enter a gene name.' : 'Enter a gene name or enter a phenotype term.'
-                  self.onShowSnackbar( {message: theMessage, timeout: 5000});
+                  self.onShowSnackbar( {message: theMessage, timeout: 10000, closeable: true});
                   self.bringAttention = 'gene';
                 }
 
@@ -1574,7 +1574,7 @@ export default {
               })
             } else {
               let theMessage = self.isSimpleMode || self.isBasicMode ? 'Enter a gene name.' : 'Enter a gene name or enter a phenotype term.'
-              self.onShowSnackbar( {message: theMessage, timeout: 5000});
+              self.onShowSnackbar( {message: theMessage, timeout: 10000, closeable: true});
               self.bringAttention = 'gene';
               resolve();
             }
@@ -1824,7 +1824,7 @@ export default {
           }
         } else {
           let theMessage = self.isSimpleMode || self.isBasicMode ? 'Enter a gene name.' : 'Enter a gene name or enter a phenotype term.'
-          self.onShowSnackbar( {message: theMessage, timeout: 5000});
+          self.onShowSnackbar( {message: theMessage, timeout: 10000, closeable: true});
           self.bringAttention = 'gene';
           if (callback) {
             callback();


### PR DESCRIPTION
The issue with the incorrect text being displayed when gene is launched without a phenotype search bar has already been fixed (Nebula was not up to date with newer versions of gene). 

 Al mentioned to break up the 'Enter a gene name or phenotype term' into two separate dialogs.  Currently, snack bars are not set up in a way to easily display multiple snack bars at the same time in a centered container.  I have instead increased the duration that the message is available, and made it closeable. 

At this point in time, I believe the dialog message to be sufficiently clear for all modes of gene.iobio, and suggest we move the request to break up the message into two separate messages, and better align the Nebula specific message into a lower priority issue.  Is this approach okay with everyone?


<img width="468" alt="Screen Shot 2020-10-09 at 11 27 39 AM" src="https://user-images.githubusercontent.com/15776714/95613652-81561400-0a22-11eb-8807-4bddcb1e1057.png">


<img width="486" alt="Screen Shot 2020-10-09 at 11 25 24 AM" src="https://user-images.githubusercontent.com/15776714/95613656-81eeaa80-0a22-11eb-9a87-321394394bd0.png">

