### PR TITLE
Click detection

### DIFF
--- a/.idea/gene.iobio.vue.iml
+++ b/.idea/gene.iobio.vue.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="R User Library" level="project" />
+    <orderEntry type="library" name="R Skeletons" level="application" />
+  </component>
+</module>

--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -3951,7 +3951,7 @@ export default {
             }
           })
         })
-        if ((self.paramAnalysisId || self.paramVariantSetId || !self.geneClicked) && firstFlaggedVariant) {
+        if ((self.paramAnalysisId || self.paramVariantSetId || !self.geneClicked) && firstFlaggedVariant && !getGeneName(firstFlaggedVariant) === self.selectedGene.gene_name) {
           self.promiseLoadGene(getGeneName(firstFlaggedVariant))
             .then(function() {
               self.toClickVariant = firstFlaggedVariant;

--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -1940,7 +1940,6 @@ export default {
     onGeneClicked: function(geneName) {
       var self = this;
 
-      console.log("onGeneClicked", );
       self.geneClicked = true;
 
       self.deselectVariant();

--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -3952,7 +3952,8 @@ export default {
             }
           })
         })
-        if ((self.paramAnalysisId || self.paramVariantSetId || !self.geneClicked) && firstFlaggedVariant && !getGeneName(firstFlaggedVariant) === self.selectedGene.gene_name) {
+        console.log("self.geneClicked", self.geneClicked);
+        if ((self.paramAnalysisId || self.paramVariantSetId || !self.geneClicked) && firstFlaggedVariant &&  (!self.selectedGene || getGeneName(firstFlaggedVariant) !== self.selectedGene.gene_name)) {
           self.promiseLoadGene(getGeneName(firstFlaggedVariant))
             .then(function() {
               self.toClickVariant = firstFlaggedVariant;

--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -2194,6 +2194,7 @@ export default {
     },
     onGeneRegionZoomReset: function() {
       this.showZoom = false;
+      this.clearZoom = true;
       this.geneRegionStart = this.selectedGene.start;
       this.geneRegionEnd = this.selectedGene.end;
 

--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -3952,7 +3952,7 @@ export default {
             }
           })
         })
-        if (self.launchedFromClin || (self.paramAnalysisId || self.paramVariantSetId || !self.geneClicked) && firstFlaggedVariant) {
+        if ((self.paramAnalysisId || self.paramVariantSetId || !self.geneClicked) && firstFlaggedVariant) {
           self.promiseLoadGene(getGeneName(firstFlaggedVariant))
             .then(function() {
               self.toClickVariant = firstFlaggedVariant;

--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -940,6 +940,7 @@ export default {
       geneRegionStart: null,
       geneRegionEnd: null,
       geneLists: null,
+      geneClicked: false,
 
       genesInProgress: {},
 
@@ -1938,6 +1939,9 @@ export default {
 
     onGeneClicked: function(geneName) {
       var self = this;
+
+      console.log("onGeneClicked", );
+      self.geneClicked = true;
 
       self.deselectVariant();
 
@@ -3948,7 +3952,7 @@ export default {
             }
           })
         })
-        if (self.launchedFromClin || (self.paramAnalysisId && firstFlaggedVariant) || (self.paramVariantSetId && firstFlaggedVariant)) {
+        if (self.launchedFromClin || (self.paramAnalysisId || self.paramVariantSetId || !self.geneClicked) && firstFlaggedVariant) {
           self.promiseLoadGene(getGeneName(firstFlaggedVariant))
             .then(function() {
               self.toClickVariant = firstFlaggedVariant;

--- a/client/app/components/viz/VariantAllCard.vue
+++ b/client/app/components/viz/VariantAllCard.vue
@@ -1241,6 +1241,7 @@ export default {
       this.$emit('gene-region-zoom', regionStart, regionEnd);
     },
     onRegionZoomReset: function() {
+      this.showZoom = false;
       this.zoomMessage = "Drag to zoom";
       this.$emit('gene-region-zoom-reset');
     },


### PR DESCRIPTION
This PR addresses the inconsistency in focus changing on analyzeAll completed.  Clin and gene should now have the same behavior.  If a user clicks a gene before the analysis is completed, they will not lose focus of the gene card on analysis complete, but the gene tab will switch to the variant tab.  If a user does not select a gene, their focus will be changed to the first flagged variant and the corresponding gene