### PR TITLE
clin - variants notes report findings fix

### DIFF
--- a/client/app/components/pages/GeneHome.vue
+++ b/client/app/components/pages/GeneHome.vue
@@ -2938,6 +2938,10 @@ export default {
         variant.interpretation = 'unknown-sig';
         self.onApplyVariantInterpretation(variant);
       }
+      
+      if (self.launchedFromClin) {
+        self.promiseUpdateAnalysisVariant(variant, {delay: false});
+      }
 
     },
 


### PR DESCRIPTION
This PR fixes the following in clin.iobio: Notes were not added to the findings page after significance was attached. For example: Add a note to a variant > Unknown significance is added > Variants also shows up on the "report-findings" page with the note that was added. > Now add another note to the same variant > New note is added in the "review variants" but does not show up in the "report findings". 

To test: 

- Pull the latest version of clin from the `dev` branch. 
- Launch clin.iobio with the demo data 
- Go to review variants 
- Add a note to a variant
- This variant should be shown on the report-findings page with unknown significance. 
- Add another note to the same variant. report-findings page should show this note. 


- Select another variant 
- Add a significance to it (Significant)
- Add notes to this variant 
- Go to the report findings page,. The new variant should be there with the notes. 