### PR TITLE
#561 Move allele count bars up for parents so that affected symbol do…

### DIFF
--- a/client/app/d3/PedigreeGenotypeChart.d3.js
+++ b/client/app/d3/PedigreeGenotypeChart.d3.js
@@ -43,7 +43,7 @@ export default function PedigreeGenotypeChartD3() {
         }
         else if(nodeData.sex === "male"){
             parent.append("g")
-                .attr("transform", "translate(-" + (nodeWidth / 1.75) + ", -" + (nodeWidth / 2) + ")")
+                .attr("transform", "translate(-" + (nodeWidth / 1.75) + ", -" + (nodeWidth / 2 -1) + ")")
                 .append("use")
                 .attr("xlink:href", "#affected-symbol")
                 .attr("class", "level-high")
@@ -221,7 +221,7 @@ export default function PedigreeGenotypeChartD3() {
             group
                 .attr("transform", function (d, i) {
                     if (position == "top") {
-                        return "translate(-10,-12)";
+                        return "translate(-10,-18)";
                     } else {
                         return "translate(-10," + (nodeWidth + 20) + ")";
                     }
@@ -232,7 +232,7 @@ export default function PedigreeGenotypeChartD3() {
             group
                 .attr("transform", function (d, i) {
                     if (position == "top") {
-                        return "translate(-10,-12)";
+                        return "translate(-10,-18)";
                     } else {
                         return "translate(-10," + (nodeWidth + 10) + ")";
                     }


### PR DESCRIPTION
…esn't overlap the bars.

To test, run demo data.  Then in files dialog, toggle mom and dad to 'affected'.  Click on RAI1 variant and the genotype/pedigree chart should have enough room for affected glyphs on parent and allele count bars.
<img width="152" alt="Screen Shot 2020-11-20 at 7 09 34 PM" src="https://user-images.githubusercontent.com/8420103/99865027-37556780-2b64-11eb-9550-3c18ef3c6d9e.png">
